### PR TITLE
APS/MedStar Merge

### DIFF
--- a/data_management/aps_cleaning_01_initial_clean.qmd
+++ b/data_management/aps_cleaning_01_initial_clean.qmd
@@ -124,9 +124,8 @@ There were 985 observations (in 925 APS Subject IDs) which did not have an exclu
             -   115 remaining APS Person ID values in 415 observations with variation in Street Name
 
             -   40 remaining APS Person ID values in 158 observations with variation in Street Number
-            
-    -   Manual verification of 74 APS Person ID values, which were connected to Case Numbers that referred more than one APS Person ID 
-            -   Reconciliation of these 74 APS Person ID values into 37 Person ID Values (37 value reduction)
+
+    -   Manual verification of 74 APS Person ID values, which were connected to Case Numbers that referred more than one APS Person ID - Reconciliation of these 74 APS Person ID values into 37 Person ID Values (37 value reduction)
 
 # Imports
 
@@ -344,7 +343,6 @@ get_all_cases_persons <- function(df, case_list) {
   
 }
 ```
-
 
 # Initial Data Structure
 
@@ -1340,10 +1338,45 @@ We expected values for Close Reason to be standardized and selected from a pre-d
 get_unique_value_summary(aps,'aps_inv_close_reason')
 ```
 
-We finally converted the variable to an unordered factor.
+As closure reasons extend to the entire investigation (Case Number), these were consolidated to be identical across all occurrences of the same APS Case Number. Occurrences with only values of "Closed to Merge" were considered still ongoing, as no full closure reason was located in our Data Set. 
+
+Closures of both "Progress to Maintenance" and "Progress to ICS" indicated continued following by APS Services; as such, these were consolidated into "Progress to Maintenance or ICS" as there were Case Numbers with both closure reasons.
 
 ```{r}
-aps$aps_inv_close_reason <- as.factor(aps$aps_inv_close_reason)
+aps <- aps %>%
+  mutate(aps_inv_close_reason = na_if(aps_inv_close_reason, "Closed to Merge"),
+         aps_inv_close_reason = if_else(
+           (aps_inv_close_reason %in% 
+              c("Progress to Maintenance", "Progress to ICS")), 
+           "Progress to Maintenance or ICS", aps_inv_close_reason)
+         )
+```
+
+We created a map of Case Numbers and Closure Reasons, where the unique closure reason for each Case would be stored as a factor.
+
+```{r}
+case_closures <- aps %>%
+  filter(!is.na(aps_inv_close_reason)
+         ) %>%
+  group_by(aps_case_num) %>%
+  mutate(aps_close_list = unique(list(aps_inv_close_reason)),
+         ) %>%
+  ungroup() %>%
+  rowwise() %>%
+  mutate(aps_inv_close_reason = as.character(
+    list(na.omit(unique(aps_close_list))))
+         ) %>%
+  ungroup() %>%
+  select(aps_case_num, aps_inv_close_reason) %>%
+  distinct()
+
+case_closures$aps_inv_close_reason <- as.factor(case_closures$aps_inv_close_reason)
+```
+
+We finally applied this map to update our values.
+
+```{r}
+aps <- rows_update(aps, case_closures, by = 'aps_case_num')
 ```
 
 ### Intake Date/Time `aps_intake_dt`
@@ -2250,7 +2283,7 @@ length(unique(search$aps_case_num))
 length(unique(search$aps_person_id))
 ```
 
-Each group was evaluated separately. With the exception of one group (group 24), all groups appeared to be entirely valid pairings. 
+Each group was evaluated separately. With the exception of one group (group 24), all groups appeared to be entirely valid pairings.
 
 ```{r}
 case_nums <- unique(checking$aps_case_num)
@@ -2269,7 +2302,7 @@ aps$aps_person_id[aps$aps_row == 6079] <- aps$aps_person_id[aps$aps_row == 6078]
 case_nums <- case_nums[-24]
 ```
 
-For all other observations, a replacement map was created to facilitate corrections in both this data set, and in potential future APS data sets, to ensure consistency throughout the project. The first APS Person ID associated with the group was selected to be kept.  
+For all other observations, a replacement map was created to facilitate corrections in both this data set, and in potential future APS data sets, to ensure consistency throughout the project. The first APS Person ID associated with the group was selected to be kept.
 
 ```{r}
 fix_map <- tibble(
@@ -2306,7 +2339,6 @@ for (i in 1:length(case_nums)){
   get_all_cases_persons(aps, case_nums[i])
 }
 ```
-
 
 In addition to manually checking the result, checking the full data set for any Case Numbers with more than one APS Person ID value finds that there are no remaining unfixed Case Number groups.
 
@@ -2410,4 +2442,3 @@ The map of APS Person ID replacements was saved and exported.
 ```{r}
 saveRDS(fix_map, here("data", "DETECT Shared GRAs", "aps_cleaning", "aps_id_replacement_map.rds"))
 ```
-

--- a/data_management/aps_cleaning_02_determination_vars.qmd
+++ b/data_management/aps_cleaning_02_determination_vars.qmd
@@ -1,0 +1,588 @@
+---
+title: "Refining APS Clean for Determination Variables"
+format: html
+editor: visual
+---
+
+# Summary
+
+-   We obtained clarifying information from Texas APS regarding determination variables, which were unclear at the time of the initial APS data set cleaning.
+
+    -   Per APS, each determination column indicated that there was at least one allegation (perpetrator-victim pair) for the determination in the category of elder mistreatment for the observation. As such, a single observation may contain multiple determinations per category of elder mistreatment.
+
+-   We generated new variables to indicate the overall determination in each category of elder mistreatment in all groupings (Row/Intake, Case Number, and APS Person ID).
+    -   `aps_rows_abuse_emotional`, `aps_cases_abuse_emotional`, `aps_subject_abuse_emotional`, etc
+    
+-   We were able to drop all binary determination variables, the determination flag variable, the total variables, and initial determination variables.
+
+-   We generated new variables to indicate if any report across each grouping (Row/Intake, Case Number, and APS Person ID) was made by EMS, or more broadly by Healthcare Staff.
+
+-   `aps_rows_reporter_ems`, `aps_rows_reporter_health`, etc.
+
+-   We isolated the earliest Intake Date and latest Investigation Closure date across each grouping (Row/Intake, Case Number, and APS Person ID) to facilitate comparison when merged with the MedStar Data Set.
+
+# Imports
+
+## Library Imports
+
+```{r}
+#| message: false
+#| warning: false
+
+library(tidyverse)
+library(here)
+```
+
+## Data Imports
+
+The originally cleaned APS Data set was loaded for processing.
+
+```{r}
+aps <- readRDS(here("data","DETECT Shared GRAs","aps_cleaning",
+                             "aps_01.rds"))
+```
+
+## Functions
+
+### Unique Value Summaries
+
+A previously written function, written to display counts of each unique observations within a selection of columns, was added for our processing.
+
+```{r}
+get_unique_value_summary <- function(df,cols){
+  
+  # Input: 
+  #     df (data frame) - original source data frame
+  #     cols (list) - list of target column names as strings
+  # Output:
+  #     unique_summary (data frame) - summary counts of each unique value in
+  #           each of the target columns
+  
+  # Get list of unique values in all target columns
+  
+  val <- unique(as.factor(as.vector(as.matrix(df[cols]))))
+  
+  # Initialize output data frame with unique value row
+  
+  unique_summary <- data.frame("value"=val)
+  
+  # Get counts of unique values in original data frame
+  
+  for (i in cols){
+    
+    # utilizes table to get summary count of each column
+    
+    table <- as.data.frame(table(df[i]))
+    
+    # sets column names to "value" and "freq"
+    
+  colnames(table) <- c("value","freq")
+  
+    # adds count of missing values in each column
+  
+  table<- add_row(table, value = NA, freq = sum(is.na(df[i])))
+  
+    # readjusts names of columns to "value" and the name of the target column
+  
+  colnames(table) <- c("value",i)
+  
+    # joins table's summary counts to complete the count values
+  
+    unique_summary <- left_join(unique_summary,table, by="value")
+  }
+  
+  # returns completed, but unordered, data frame
+  
+  unique_summary
+  }
+```
+
+### Redefining APS Determinations
+
+A convenience function was written to facilitate modifying elder mistreatment determinations by category across a variety of groupings.
+
+```{r}
+redefine_aps_determinations <- function(aps_df, target_category, 
+                                        grouping = NA_character_, output_var){
+  #
+  #   Facilitates adjustment of APS Determinations by category, and by groups.
+  #
+  #
+  # Input: 
+  #     aps_df:               data frame. APS data frame
+  #     target_category:      string. The target category as it appears in
+  #                           the variables
+  #     grouping:             string. The variable to group by.
+  #                           Default is a null value, indicating no groups
+  #     output_var:           string. Prefix for the output variable
+  #
+  # Output:
+  #     aps_df:               data frame. The input data frame, with new
+  #                           variable
+  
+  # Groups based on the grouping variable.
+  # If no grouping variable, groups with rowwise()
+  
+  if (is.na(grouping)){
+    mod_df <- aps_df %>%
+      select(contains(c('aps_row',target_category))
+             ) %>%
+      rowwise()
+  }
+  
+  if (!is.na(grouping)){
+  
+  
+  mod_df <- aps_df %>%
+    
+    # Isolates the row number (needed to add to source), grouping variable,
+    # and variables associated with the target category
+    
+    select(contains(c('aps_row', grouping, target_category))
+           ) %>%
+    # Groups by the grouping variable
+    
+    group_by(pick(all_of(grouping))
+             ) 
+  
+  }
+  
+  mod_df <- mod_df %>%
+    mutate(
+      
+    # Calculates the number of valid, invalid, unable to determine, and other
+    # determinations (which are stored in individual variables) in the group
+      
+      n_v = sum(pick(contains('_valid'))),
+      n_i = sum(pick(contains('_invalid'))),
+      n_u = sum(pick(contains('_utd'))),
+      n_o = sum(pick(contains('_other')))
+    ) %>%
+    mutate(out_var = case_when(
+      
+      # Creates the output variable with the overall categorical determination 
+      # for the group as a whole
+      
+      # No allegations
+      (n_v == 0 & n_i == 0 & n_u == 0 & n_o == 0) ~ 
+        "No Allegations with Determinations",
+      
+      # Only one determination
+      (n_v > 0 & n_i == 0 & n_u == 0 & n_o == 0) ~ 
+        "All Allegations Valid",
+      (n_v == 0 & n_i > 0 & n_u == 0 & n_o == 0) ~ 
+        "All Allegations Invalid",
+      (n_v == 0 & n_i == 0 & n_u > 0 & n_o == 0) ~ 
+        "All Allegations Unable to Determine",
+      (n_v == 0 & n_i == 0 & n_u == 0 & n_o > 0) ~ 
+        "All Allegations Other - Not Investigated",
+      
+      # At least one valid determination
+      (n_v > 0 & n_i > 0 & n_u == 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with Invalid Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u > 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with Invalid and UTD Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u == 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Invalid and Other Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u > 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u > 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with UTD Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u > 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with UTD and Other Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u == 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Other Allegation(s)",
+      
+      # No valid determinations
+      (n_v == 0 & n_i > 0 & n_u > 0 & n_o == 0) ~
+        "No Valid Determinations, All Invalid or UTD",
+      (n_v == 0 & n_i > 0 & n_u == 0 & n_o > 0) ~
+        "No Valid Determinations, All Invalid or Other",
+      (n_v == 0 & n_i == 0 & n_u > 0 & n_o > 0) ~
+        "No Valid Determinations, All UTD or Other",
+      (n_v == 0 & n_i > 0 & n_u > 0 & n_o > 0) ~
+        "No Valid Determinations, All Invalid, UTD, or Other",
+      )
+    ) %>%
+    
+    # Ungroups the data frame
+  
+    ungroup()
+    
+  # Renames the output variable
+  
+  names(mod_df)[names(mod_df) == 'out_var'] <- paste(output_var, target_category, sep = "_")
+  
+  # Isolates Row Number and the Output Variable
+    
+  mod_df <- mod_df %>% select(aps_row, ncol(mod_df))
+  
+  # Adds the new variable to the aggregate data frame
+  
+  aps_df <- left_join(aps_df, mod_df, by="aps_row")
+  
+  # Returns output
+  
+  aps_df
+}
+```
+
+# Cleaning Determination Variables
+
+## By Observation
+
+In conference with APS, we learned that our determination variables represented that *at least one* allegation of a particular category of elder mistreatment was found to have the given determination. As such, an observation which indicated a 1 for both "Emotional Abuse Valid" and "Emotional Abuse Invalid" may have multiple allegations (perpetrator-victim pairs) of Emotional Abuse that were found to be Valid or Invalid, but at least one allegation was found to be valid and at least one was found to be invalid.
+
+As such, we had to adjust our interpretation so that a value of 1 in "Valid" indicated "At least one valid allegation." 
+
+```{r}
+aps <- aps %>%
+  redefine_aps_determinations('exploitation', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('abuse_sexual', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('abuse_emotional', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('abuse_physical', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('neglect_physical', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('neglect_medical', output_var = 'aps_rows') %>%
+  redefine_aps_determinations('neglect_mental', output_var = 'aps_rows')
+```
+
+We assigned each of our 16 determinations an order, with determinations indicating at least one valid allegation listed first.
+
+```{r}
+determination_levels <- c(
+  'All Allegations Valid',
+  'At Least One Valid Allegation, with Invalid Allegation(s)',
+  'At Least One Valid Allegation, with UTD Allegation(s)', 
+  'At Least One Valid Allegation, with Other Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid and UTD Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid and Other Allegation(s)', 
+  'At Least One Valid Allegation, with UTD and Other Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)',
+  'All Allegations Invalid', 'All Allegations Unable to Determine',
+  'All Allegations Other - Not Investigated', 
+  'No Valid Determinations, All Invalid or UTD', 
+  'No Valid Determinations, All Invalid or Other',
+  'No Valid Determinations, All UTD or Other',
+  'No Valid Determinations, All Invalid, UTD, or Other',
+  'No Allegations with Determinations')
+
+row_determination_vars <- c('aps_rows_abuse_emotional', 'aps_rows_exploitation',
+                            'aps_rows_neglect_medical', 'aps_rows_neglect_mental', 
+                            'aps_rows_abuse_physical', 'aps_rows_neglect_physical',
+                            'aps_rows_abuse_sexual')
+
+aps <- aps %>%
+  mutate(across(all_of(row_determination_vars), 
+                ~factor(.x, ordered = TRUE, levels = determination_levels)
+                  )
+         )
+```
+
+We verified our assignments were complete.
+
+```{r}
+get_unique_value_summary(aps, row_determination_vars)
+```
+
+## By Case Number
+
+Each observation in the data set corresponded to a unique Intake event. Each investigation was associated with a single Case Number. As such, we generated variables that contained values summarizing all the observations represented in a single case Number.
+
+```{r}
+aps <- aps %>%
+  group_by(aps_case_num) %>%
+  mutate(aps_cases_num_intakes = n_distinct(aps_row)) %>%
+  ungroup()
+```
+
+We verified that our new variable was created without unexpected values.
+
+```{r}
+get_unique_value_summary(aps,'aps_cases_num_intakes')
+```
+
+We then assigned the values for the determinations across every instance of each Case Number.
+
+```{r}
+aps <- aps %>%
+  redefine_aps_determinations('exploitation', grouping = "aps_case_num", 
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('abuse_sexual', grouping = "aps_case_num",
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('abuse_emotional', grouping = "aps_case_num",
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('abuse_physical', grouping = "aps_case_num",
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('neglect_physical', grouping = "aps_case_num",
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('neglect_medical', grouping = "aps_case_num",
+                              output_var = 'aps_cases') %>%
+  redefine_aps_determinations('neglect_mental', grouping = "aps_case_num",
+                              output_var = 'aps_cases')
+```
+
+We assigned each of our 16 determinations an order, with determinations indicating at least one valid allegation listed first.
+
+```{r}
+case_determination_vars <- c(
+                        'aps_cases_abuse_emotional', 'aps_cases_exploitation',
+                        'aps_cases_neglect_medical', 'aps_cases_neglect_mental', 
+                        'aps_cases_abuse_physical', 'aps_cases_neglect_physical',
+                        'aps_cases_abuse_sexual')
+
+aps <- aps %>%
+  mutate(across(all_of(case_determination_vars), 
+                ~factor(.x, ordered = TRUE, levels = determination_levels)
+                  )
+         )
+```
+
+We verified our assignments were complete.
+
+```{r}
+get_unique_value_summary(aps, case_determination_vars)
+```
+
+## By Subject
+
+Each subject in the data set, represented by a unique APS Person ID, potentially had multiple Case Numbers assigned over the data set time period. As such, we generated variables that contained values summarizing all the observations represented in a single APS Person ID and the number of cases represented in a single APS Person ID. 
+
+```{r}
+aps <- aps %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_num_intakes = n_distinct(aps_row),
+         aps_subject_num_cases = n_distinct(aps_case_num)
+         ) %>%
+  ungroup()
+
+```
+
+We verified that our new variable was created without unexpected values.
+
+```{r}
+get_unique_value_summary(aps,
+                         c('aps_subject_num_intakes','aps_subject_num_cases'))
+```
+
+We then assigned the values for the determinations across every instance of each Case Number.
+
+```{r}
+aps <- aps %>%
+  redefine_aps_determinations('exploitation', grouping = "aps_person_id", 
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('abuse_sexual', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('abuse_emotional', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('abuse_physical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('neglect_physical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('neglect_medical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_aps_determinations('neglect_mental', grouping = "aps_person_id",
+                              output_var = 'aps_subject')
+
+```
+
+We assigned each of our 16 determinations an order, with determinations indicating at least one valid allegation listed first.
+
+```{r}
+subject_determination_vars <- c(
+  'aps_subject_abuse_emotional', 'aps_subject_exploitation',
+  'aps_subject_neglect_medical', 'aps_subject_neglect_mental',
+  'aps_subject_abuse_physical', 'aps_subject_neglect_physical',
+  'aps_subject_abuse_sexual')
+
+aps <- aps %>%
+  mutate(across(all_of(subject_determination_vars), 
+                ~factor(.x, ordered = TRUE, levels = determination_levels)
+                  )
+         )
+```
+
+We verified our assignments were complete.
+
+```{r}
+get_unique_value_summary(aps, subject_determination_vars)
+```
+
+# Dropping Revised Variables
+
+As the assignments were complete, we were able to drop the individual columns listing "valid", "invalid", "other", or "utd" determinations for each category of elder mistreatment. We were also able to drop the determination flag variable `flag_determinations` and the "total" variables for each category. We also dropped the original "total determination by category" variables.
+
+```{r}
+aps <- aps %>%
+  select (-c(contains("_valid"), contains("_invalid"), contains("_utd"), 
+             contains("_other"), contains("total"), 'flag_determinations')
+          ) %>%
+  select( -c("aps_abuse_emotional", "aps_exploitation", "aps_neglect_medical",
+             "aps_neglect_mental", "aps_neglect_physical", "aps_abuse_physical",
+             "aps_abuse_sexual"))
+```
+
+# Adding Binary Indicators
+
+## At Least One Valid Allegation of Any Type
+
+The first eight determination values indicated that at least one allegation of elder mistreatment was found to be valid.
+
+```{r}
+determination_levels[1:8]
+```
+
+We flagged the observations in our data set based on if there were any valid allegations in any category of elder mistreatment for each intake/row, Case Number, and Subject ID.
+
+```{r}
+aps <- aps %>%
+  rowwise() %>%
+  mutate(aps_rows_any_valid = if_any(all_of(row_determination_vars), 
+                            .fns = ~.x %in% determination_levels[1:8]),
+         aps_cases_any_valid = if_any(all_of(case_determination_vars), 
+                            .fns = ~.x %in% determination_levels[1:8]),
+         aps_subject_any_valid = if_any(all_of(subject_determination_vars), 
+                            .fns = ~.x %in% determination_levels[1:8])
+         ) %>%
+  ungroup()
+```
+
+Based on our flag, we expected 7,959 observations to indicate at least one valid allegation across the individual observations.
+
+```{r}
+get_unique_value_summary(aps, c('aps_rows_any_valid', 'aps_cases_any_valid',
+                         'aps_subject_any_valid'))
+```
+
+## No Determinations of Any Type
+
+We flagged any observation where all determinations were equal to the final value of the determination levels, "No Allegations with Determinations."
+
+```{r}
+aps <- aps %>%
+  rowwise() %>%
+  mutate(aps_rows_none = if_all(all_of(row_determination_vars),
+                                .fns = ~.x %in% determination_levels[16]),
+         aps_cases_none = if_all(all_of(case_determination_vars),
+                                .fns = ~.x %in% determination_levels[16]),
+         aps_subject_none = if_all(all_of(subject_determination_vars),
+                                .fns = ~.x %in% determination_levels[16]),
+         ) %>%
+  ungroup()
+```
+
+We verified our assignments did not result in any unanticipated values.
+
+```{r}
+get_unique_value_summary(aps,
+                c('aps_rows_none', 'aps_cases_none', 'aps_subject_none'))
+```
+
+## EMS Reporter
+
+The reporter category "Health Care Providers/Staff -- EMS/EMT" was designated to indicate reports by EMS.
+
+```{r}
+get_unique_value_summary(aps, 'aps_reporter')
+```
+
+We added binary variables which would indicate if any observation within a grouping (Row/Intake, Case Number, APS Person ID) had an EMS Reporter.
+
+```{r}
+aps <- aps %>%
+  mutate(aps_rows_reporter_ems = if_else(
+    aps_reporter == "Health Care Providers/Staff -- EMS/EMT",
+    TRUE,
+    FALSE)
+    ) %>%
+  group_by(aps_case_num) %>% 
+  mutate(aps_cases_reporter_ems = case_when(
+    sum(aps_rows_reporter_ems, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_rows_reporter_ems), na.rm = TRUE) > 0 & 
+       sum(aps_rows_reporter_ems, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup() %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_reporter_ems = case_when(
+    sum(aps_cases_reporter_ems, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_cases_reporter_ems), na.rm = TRUE) > 0 & 
+       sum(aps_cases_reporter_ems, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup()
+```
+
+We checked our assignments and found no unexpected results.
+
+```{r}
+get_unique_value_summary(aps,
+                         c('aps_rows_reporter_ems', 'aps_cases_reporter_ems',
+                           'aps_subject_reporter_ems'))
+```
+
+## Healthcare Reporter
+
+The reporter category "Health Care Providers/Staff -- EMS/EMT" was a distinct from "Health Care Providers/Staff", but appeared to be a subset. Anticipating the possibility of an EMS report being mistakenly classified as "Health Care Providers/Staff" instead of "Health Care Providers/Staff -- EMS/EMT", we generated binary variables which would incidate if any observation within a grouping (Row/Intake, Case Number, APS Person ID) had a Healthcare Reporter.
+
+
+```{r}
+aps <- aps %>%
+  mutate(aps_rows_reporter_health = if_else((
+    aps_reporter == "Health Care Providers/Staff -- EMS/EMT" |
+      aps_reporter == "Health Care Providers/Staff"),
+    TRUE,
+    FALSE)
+    ) %>%
+  group_by(aps_case_num) %>% 
+  mutate(aps_cases_reporter_health = case_when(
+    sum(aps_rows_reporter_health, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_rows_reporter_health), na.rm = TRUE) > 0 & 
+       sum(aps_rows_reporter_health, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup() %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_reporter_health = case_when(
+    sum(aps_cases_reporter_health, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_cases_reporter_health), na.rm = TRUE) > 0 & 
+       sum(aps_cases_reporter_health, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup()
+```
+
+We checked our assignments and found no unexpected results.
+
+```{r}
+get_unique_value_summary(aps, 
+                         c('aps_rows_reporter_health', 
+                           'aps_cases_reporter_health', 
+                           'aps_subject_reporter_health'))
+```
+
+# Flagging Earliest Case Open Date
+
+We created variables to flag the earliest Case Open date, and latest Investigation Close date, for the observations within a grouping (Row/Investigation, Case Number, APS Person ID).
+
+```{r}
+aps <- aps %>%
+  group_by(aps_case_num) %>%
+  mutate(aps_cases_earliest = min(aps_intake_date),
+         aps_cases_latest = max(aps_inv_close_date)
+         ) %>%
+  ungroup() %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_earliest = min(aps_intake_date),
+         aps_subject_latest = max(aps_inv_close_date)
+         ) %>%
+  ungroup()
+```
+
+# Save and Export
+
+We saved and exported the revised APS Data Set.
+
+```{r}
+saveRDS(aps, here("data", "DETECT Shared GRAs", "aps_cleaning", "aps_02.rds"))
+```
+

--- a/data_management/aps_cleaning_03_revisions_after_merge_map.qmd
+++ b/data_management/aps_cleaning_03_revisions_after_merge_map.qmd
@@ -1,0 +1,477 @@
+---
+title: "Revising Post-Merge APS Clean"
+format: html
+editor: visual
+---
+
+# Summary
+
+-   After APS/MedStar Merge, several APS Person ID Values were merged. As such, the "Subject ID Level" Variables required revising to ensure accuracy.
+
+# Imports
+
+## Library Imports
+
+```{r}
+#| message: false
+#| warning: false
+
+library(tidyverse)
+library(here)
+```
+
+## Data Imports
+
+The originally cleaned APS Data set was loaded for processing.
+
+```{r}
+aps <- readRDS(here("data","DETECT Shared GRAs",
+                             "aps_03.rds")) %>%
+  relocate(aps_row)
+```
+
+## Functions
+
+### Unique Value Summaries
+
+A previously written function, written to display counts of each unique observations within a selection of columns, was added for our processing.
+
+```{r}
+get_unique_value_summary <- function(df,cols){
+  
+  # Input: 
+  #     df (data frame) - original source data frame
+  #     cols (list) - list of target column names as strings
+  # Output:
+  #     unique_summary (data frame) - summary counts of each unique value in
+  #           each of the target columns
+  
+  # Get list of unique values in all target columns
+  
+  val <- unique(as.factor(as.vector(as.matrix(df[cols]))))
+  
+  # Initialize output data frame with unique value row
+  
+  unique_summary <- data.frame("value"=val)
+  
+  # Get counts of unique values in original data frame
+  
+  for (i in cols){
+    
+    # utilizes table to get summary count of each column
+    
+    table <- as.data.frame(table(df[i]))
+    
+    # sets column names to "value" and "freq"
+    
+  colnames(table) <- c("value","freq")
+  
+    # adds count of missing values in each column
+  
+  table<- add_row(table, value = NA, freq = sum(is.na(df[i])))
+  
+    # readjusts names of columns to "value" and the name of the target column
+  
+  colnames(table) <- c("value",i)
+  
+    # joins table's summary counts to complete the count values
+  
+    unique_summary <- left_join(unique_summary,table, by="value")
+  }
+  
+  # returns completed, but unordered, data frame
+  
+  unique_summary
+  }
+```
+
+### Redefining APS Determinations
+
+A convenience function was written to facilitate modifying elder mistreatment determinations by category across a variety of groupings. This function was specifically written to facilitate revision after the original binary categorical variables were dropped from the data set.
+
+```{r}
+redefine_determinations_modified <- function(aps_df, target_category, 
+                                        grouping = 'aps_case_num', output_var){
+  #
+  #   Facilitates adjustment of APS Determinations by category, and by groups,
+  #   after the initial variable cleaning (thus binary vars were dropped)
+  #
+  #
+  # Input: 
+  #     aps_df:               data frame. APS data frame
+  #     target_category:      string. The target category as it appears in
+  #                           the variables
+  #     grouping:             string. The variable to group by.
+  #                           Default is Case Number
+  #     output_var:           string. Prefix for the output variable
+  #
+  # Output:
+  #     aps_df:               data frame. The input data frame, with new
+  #                           variable
+  
+
+  # Overall row-wise determinations relating to each type of determination:
+    
+  n_v_ds <- c(
+    'All Allegations Valid',
+    'At Least One Valid Allegation, with Invalid Allegation(s)',
+    'At Least One Valid Allegation, with UTD Allegation(s)', 
+    'At Least One Valid Allegation, with Other Allegation(s)', 
+    'At Least One Valid Allegation, with Invalid and UTD Allegation(s)', 
+    'At Least One Valid Allegation, with Invalid and Other Allegation(s)', 
+    'At Least One Valid Allegation, with UTD and Other Allegation(s)', 
+    'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)')
+  
+  n_i_ds <- c(
+    'At Least One Valid Allegation, with Invalid Allegation(s)',
+    'At Least One Valid Allegation, with Invalid and UTD Allegation(s)',
+    'At Least One Valid Allegation, with Invalid and Other Allegation(s)',
+    'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)', 
+    'All Allegations Invalid', 
+    'No Valid Determinations, All Invalid or UTD', 
+    'No Valid Determinations, All Invalid or Other',
+    'No Valid Determinations, All Invalid, UTD, or Other'
+  )
+  
+  n_u_ds <- c(
+    'All Allegations Unable to Determine',
+    'At Least One Valid Allegation, with UTD Allegation(s)',
+    'At Least One Valid Allegation, with Invalid and UTD Allegation(s)',
+    'At Least One Valid Allegation, with UTD and Other Allegation(s)',
+    'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)',
+    'No Valid Determinations, All Invalid or UTD', 
+    'No Valid Determinations, All Invalid, UTD, or Other',
+    'No Valid Determinations, All UTD or Other'
+              )
+  
+  n_o_ds <- c(
+    'All Allegations Other - Not Investigated',
+    'At Least One Valid Allegation, with Other Allegation(s)', 
+    'At Least One Valid Allegation, with Invalid and Other Allegation(s)',
+    'At Least One Valid Allegation, with UTD and Other Allegation(s)', 
+    'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)',
+    'No Valid Determinations, All Invalid or Other',
+    'No Valid Determinations, All UTD or Other',
+    'No Valid Determinations, All Invalid, UTD, or Other'
+    )
+  
+  
+  # Isolates the row number, grouping variable, and row-wise target variable
+  
+  mod_df <- aps_df %>%
+    select(all_of(
+      c('aps_row', grouping, paste('aps_rows', target_category, sep= "_")))
+           )
+  
+  # Renames the target variable to facilitate mutate
+  
+  colnames(mod_df)[3] <- "target_var"
+  
+  
+  mod_df <- mod_df %>%
+      # Reverts the row-wise determination category into the binary determination
+      # variables for the target variable
+    mutate(n_v = ifelse((target_var %in% n_v_ds), 1, 0),
+           n_i = ifelse((target_var %in% n_i_ds), 1, 0),
+           n_u = ifelse((target_var %in% n_u_ds), 1, 0),
+           n_o = ifelse((target_var %in% n_o_ds), 1, 0)
+    ) %>%
+    
+      # Groups by the grouping variable
+    
+    group_by(pick(all_of(grouping))
+             ) %>%
+    
+    # Calculates the number of valid, invalid, unable to determine, and other
+    # determinations (which are stored in individual variables) in the group
+    
+    mutate(n_v = sum(n_v),
+           n_i = sum(n_i),
+           n_u = sum(n_u),
+           n_o = sum(n_o)
+           ) %>%
+      
+    mutate(out_var = case_when(
+      
+      # Creates the output variable with the overall categorical determination 
+      # for the group as a whole
+      
+      # No allegations
+      (n_v == 0 & n_i == 0 & n_u == 0 & n_o == 0) ~ 
+        "No Allegations with Determinations",
+      
+      # Only one determination
+      (n_v > 0 & n_i == 0 & n_u == 0 & n_o == 0) ~ 
+        "All Allegations Valid",
+      (n_v == 0 & n_i > 0 & n_u == 0 & n_o == 0) ~ 
+        "All Allegations Invalid",
+      (n_v == 0 & n_i == 0 & n_u > 0 & n_o == 0) ~ 
+        "All Allegations Unable to Determine",
+      (n_v == 0 & n_i == 0 & n_u == 0 & n_o > 0) ~ 
+        "All Allegations Other - Not Investigated",
+      
+      # At least one valid determination
+      (n_v > 0 & n_i > 0 & n_u == 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with Invalid Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u > 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with Invalid and UTD Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u == 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Invalid and Other Allegation(s)",
+      (n_v > 0 & n_i > 0 & n_u > 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u > 0 & n_o == 0) ~
+        "At Least One Valid Allegation, with UTD Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u > 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with UTD and Other Allegation(s)",
+      (n_v > 0 & n_i == 0 & n_u == 0 & n_o > 0) ~
+        "At Least One Valid Allegation, with Other Allegation(s)",
+      
+      # No valid determinations
+      (n_v == 0 & n_i > 0 & n_u > 0 & n_o == 0) ~
+        "No Valid Determinations, All Invalid or UTD",
+      (n_v == 0 & n_i > 0 & n_u == 0 & n_o > 0) ~
+        "No Valid Determinations, All Invalid or Other",
+      (n_v == 0 & n_i == 0 & n_u > 0 & n_o > 0) ~
+        "No Valid Determinations, All UTD or Other",
+      (n_v == 0 & n_i > 0 & n_u > 0 & n_o > 0) ~
+        "No Valid Determinations, All Invalid, UTD, or Other",
+      )
+    ) %>%
+    
+    # Ungroups the data frame
+  
+    ungroup()
+    
+  # Renames the output variable
+  
+  names(mod_df)[names(mod_df) == 'out_var'] <- paste(output_var, target_category, sep = "_")
+  
+  # Isolates Row Number and the Output Variable
+    
+  mod_df <- mod_df %>% select(aps_row, ncol(mod_df))
+  
+  # Adds the new variable to the aggregate data frame
+  
+  aps_df <- left_join(aps_df, mod_df, by="aps_row")
+  
+  # Returns output
+  
+  aps_df
+}
+```
+
+
+# Dropping Original Variables
+
+We dropped the original Subject-level variables.
+
+```{r}
+aps <- aps %>%
+  select(-c(starts_with('aps_subject_')))
+```
+
+# Cleaning Determination Variables
+
+Each subject in the data set, represented by a unique APS Person ID, potentially had multiple Case Numbers assigned over the data set time period. As such, we generated variables that contained values summarizing all the observations represented in a single APS Person ID and the number of cases represented in a single APS Person ID. 
+
+```{r}
+aps <- aps %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_num_intakes = n_distinct(aps_row),
+         aps_subject_num_cases = n_distinct(aps_case_num)
+         ) %>%
+  ungroup()
+```
+
+We verified that our new variable was created without unexpected values.
+
+```{r}
+get_unique_value_summary(aps,
+                         c('aps_subject_num_intakes','aps_subject_num_cases'))
+```
+
+We then assigned the values for the determinations across every instance of each Case Number.
+
+```{r}
+aps <- aps %>%
+  redefine_determinations_modified('exploitation', grouping = "aps_person_id", 
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('abuse_sexual', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('abuse_emotional', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('abuse_physical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('neglect_physical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('neglect_medical', grouping = "aps_person_id",
+                              output_var = 'aps_subject') %>%
+  redefine_determinations_modified('neglect_mental', grouping = "aps_person_id",
+                              output_var = 'aps_subject')
+```
+
+We assigned each of our 16 determinations an order, with determinations indicating at least one valid allegation listed first.
+
+```{r}
+determination_levels <- c(
+  'All Allegations Valid',
+  'At Least One Valid Allegation, with Invalid Allegation(s)',
+  'At Least One Valid Allegation, with UTD Allegation(s)', 
+  'At Least One Valid Allegation, with Other Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid and UTD Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid and Other Allegation(s)', 
+  'At Least One Valid Allegation, with UTD and Other Allegation(s)', 
+  'At Least One Valid Allegation, with Invalid, UTD, and Other Allegation(s)',
+  'All Allegations Invalid', 'All Allegations Unable to Determine',
+  'All Allegations Other - Not Investigated', 
+  'No Valid Determinations, All Invalid or UTD', 
+  'No Valid Determinations, All Invalid or Other',
+  'No Valid Determinations, All UTD or Other',
+  'No Valid Determinations, All Invalid, UTD, or Other',
+  'No Allegations with Determinations')
+
+
+subject_determination_vars <- c(
+  'aps_subject_abuse_emotional', 'aps_subject_exploitation',
+  'aps_subject_neglect_medical', 'aps_subject_neglect_mental',
+  'aps_subject_abuse_physical', 'aps_subject_neglect_physical',
+  'aps_subject_abuse_sexual')
+
+aps <- aps %>%
+  mutate(across(all_of(subject_determination_vars), 
+                ~factor(.x, ordered = TRUE, levels = determination_levels)
+                  )
+         )
+```
+
+We verified our assignments were complete.
+
+```{r}
+get_unique_value_summary(aps, subject_determination_vars)
+```
+
+# Adding Binary Indicators
+
+## At Least One Valid Allegation of Any Type
+
+The first eight determination values indicated that at least one allegation of elder mistreatment was found to be valid.
+
+```{r}
+determination_levels[1:8]
+```
+
+We flagged the observations in our data set based on if there were any valid allegations in any category of elder mistreatment for each intake/row, Case Number, and Subject ID.
+
+```{r}
+aps <- aps %>%
+  rowwise() %>%
+  mutate(aps_subject_any_valid = if_any(all_of(subject_determination_vars), 
+                            .fns = ~.x %in% determination_levels[1:8])
+         ) %>%
+  ungroup()
+```
+
+Based on our flag, we expected 7,959 observations to indicate at least one valid allegation across the individual observations.
+
+```{r}
+get_unique_value_summary(aps, c('aps_rows_any_valid', 'aps_cases_any_valid',
+                         'aps_subject_any_valid'))
+```
+
+## No Determinations of Any Type
+
+We flagged any observation where all determinations were equal to the final value of the determination levels, "No Allegations with Determinations."
+
+```{r}
+aps <- aps %>%
+  rowwise() %>%
+  mutate(aps_subject_none = if_all(all_of(subject_determination_vars),
+                                .fns = ~.x %in% determination_levels[16]),
+         ) %>%
+  ungroup()
+```
+
+We verified our assignments did not result in any unanticipated values.
+
+```{r}
+get_unique_value_summary(aps,
+                c('aps_rows_none', 'aps_cases_none', 'aps_subject_none'))
+```
+
+## EMS Reporter
+
+The reporter category "Health Care Providers/Staff -- EMS/EMT" was designated to indicate reports by EMS.
+
+```{r}
+get_unique_value_summary(aps, 'aps_reporter')
+```
+
+We added binary variables which would indicate if any observation within a grouping (Row/Intake, Case Number, APS Person ID) had an EMS Reporter.
+
+```{r}
+aps <- aps %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_reporter_ems = case_when(
+    sum(aps_cases_reporter_ems, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_cases_reporter_ems), na.rm = TRUE) > 0 & 
+       sum(aps_cases_reporter_ems, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup()
+```
+
+We checked our assignments and found no unexpected results.
+
+```{r}
+get_unique_value_summary(aps,
+                         c('aps_rows_reporter_ems', 'aps_cases_reporter_ems',
+                           'aps_subject_reporter_ems'))
+```
+
+## Healthcare Reporter
+
+The reporter category "Health Care Providers/Staff -- EMS/EMT" was a distinct from "Health Care Providers/Staff", but appeared to be a subset. Anticipating the possibility of an EMS report being mistakenly classified as "Health Care Providers/Staff" instead of "Health Care Providers/Staff -- EMS/EMT", we generated binary variables which would incidate if any observation within a grouping (Row/Intake, Case Number, APS Person ID) had a Healthcare Reporter.
+
+
+```{r}
+aps <- aps %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_reporter_health = case_when(
+    sum(aps_cases_reporter_health, na.rm = TRUE) > 0 ~ TRUE,
+    (sum(!(aps_cases_reporter_health), na.rm = TRUE) > 0 & 
+       sum(aps_cases_reporter_health, na.rm = TRUE) == 0) ~ FALSE,
+    TRUE ~ NA
+    )) %>% 
+  ungroup()
+```
+
+We checked our assignments and found no unexpected results.
+
+```{r}
+get_unique_value_summary(aps, 
+                         c('aps_rows_reporter_health', 
+                           'aps_cases_reporter_health', 
+                           'aps_subject_reporter_health'))
+```
+
+# Flagging Earliest Case Open Date
+
+We created variables to flag the earliest Case Open date, and latest Investigation Close date, for the observations within a grouping (Row/Investigation, Case Number, APS Person ID).
+
+```{r}
+aps <- aps %>%
+  group_by(aps_person_id) %>%
+  mutate(aps_subject_earliest = min(aps_intake_date),
+         aps_subject_latest = max(aps_inv_close_date)
+         ) %>%
+  ungroup()
+```
+
+# Save and Export
+
+We saved and exported the revised APS Data Set.
+
+```{r}
+saveRDS(aps, here("data", "DETECT Shared GRAs", "aps_04.rds"))
+```
+

--- a/data_management/aps_cleaning_03_revisions_after_merge_map.qmd
+++ b/data_management/aps_cleaning_03_revisions_after_merge_map.qmd
@@ -25,9 +25,9 @@ library(here)
 The originally cleaned APS Data set was loaded for processing.
 
 ```{r}
-aps <- readRDS(here("data","DETECT Shared GRAs",
-                             "aps_03.rds")) %>%
-  relocate(aps_row)
+aps <- readRDS(here("data","DETECT Shared GRAs", "aps_cleaning",
+                             "aps_03.rds")
+               ) %>% relocate(aps_row)
 ```
 
 ## Functions
@@ -260,7 +260,6 @@ redefine_determinations_modified <- function(aps_df, target_category,
 }
 ```
 
-
 # Dropping Original Variables
 
 We dropped the original Subject-level variables.
@@ -272,7 +271,7 @@ aps <- aps %>%
 
 # Cleaning Determination Variables
 
-Each subject in the data set, represented by a unique APS Person ID, potentially had multiple Case Numbers assigned over the data set time period. As such, we generated variables that contained values summarizing all the observations represented in a single APS Person ID and the number of cases represented in a single APS Person ID. 
+Each subject in the data set, represented by a unique APS Person ID, potentially had multiple Case Numbers assigned over the data set time period. As such, we generated variables that contained values summarizing all the observations represented in a single APS Person ID and the number of cases represented in a single APS Person ID.
 
 ```{r}
 aps <- aps %>%
@@ -432,7 +431,6 @@ get_unique_value_summary(aps,
 
 The reporter category "Health Care Providers/Staff -- EMS/EMT" was a distinct from "Health Care Providers/Staff", but appeared to be a subset. Anticipating the possibility of an EMS report being mistakenly classified as "Health Care Providers/Staff" instead of "Health Care Providers/Staff -- EMS/EMT", we generated binary variables which would incidate if any observation within a grouping (Row/Intake, Case Number, APS Person ID) had a Healthcare Reporter.
 
-
 ```{r}
 aps <- aps %>%
   group_by(aps_person_id) %>%
@@ -472,6 +470,5 @@ aps <- aps %>%
 We saved and exported the revised APS Data Set.
 
 ```{r}
-saveRDS(aps, here("data", "DETECT Shared GRAs", "aps_04.rds"))
+saveRDS(aps, here("data", "DETECT Shared GRAs", "aps_cleaning", "aps_04.rds"))
 ```
-

--- a/data_management/medstar_epcr_cleaning_01_initial_clean.qmd
+++ b/data_management/medstar_epcr_cleaning_01_initial_clean.qmd
@@ -2130,7 +2130,42 @@ ms_epcr <- ms_epcr %>%
   )
 ```
 
-The remaining 21 observations were much simpler. The alphanumeric string was isolated with are regular expression and shifted to `num_temp`, while any remaining content was shifted to `detect_report_comment`.
+There were 2 observations remaining which utilized the phrasing "REPORT" or "REFERENCE NUMBER" prior to the actual number. The alphanumeric string was isolated with a regular expression and shifted to `num_temp`, while any remaining content was shifted to `detect_report_comment`.
+
+```{r}
+checking_col <- filter(
+  ms_epcr,
+  (str_detect(ms_epcr$detect_report_num,
+              "^(REPORT|REFERENCE NUMBER)[# ]*?([0-9A-Z]+)[ \\-/]*?(.*)$")
+   )
+  )
+
+sum(!is.na(checking_col$detect_report_num))
+
+ms_epcr <- ms_epcr %>%
+  mutate(num_temp = ifelse(
+    (str_detect(detect_report_num, 
+                "^(REPORT|REFERENCE NUMBER)[# ]*?([0-9A-Z]+)[ \\-/]*?(.*)$")),
+    str_match(detect_report_num,
+              "^(REPORT|REFERENCE NUMBER)[# ]*?([0-9A-Z]+)[ \\-/]*?(.*)$")[,3],
+    num_temp
+    )
+  ) %>%
+  mutate(detect_report_comment = ifelse(
+    (str_detect(detect_report_num, 
+                "^(REPORT|REFERENCE NUMBER)[# ]*?([0-9A-Z]+)[ \\-/]*?(.*)$")),
+    str_match(detect_report_num,
+              "^(REPORT|REFERENCE NUMBER)[# ]*?([0-9A-Z]+)[ \\-/]*?(.*)$")[,4],
+    num_temp
+    )
+  ) %>%
+  mutate(detect_report_num = ifelse(!is.na(num_temp),
+                                    NA,
+                                    detect_report_num)
+  )
+```
+
+The remaining 19 observations were much simpler. The alphanumeric string was isolated with are regular expression and shifted to `num_temp`, while any remaining content was shifted to `detect_report_comment`.
 
 ```{r}
 checking_col <- filter(ms_epcr,

--- a/data_management/merge_aps_medstar/merge_aps_medstar_01_fastLink.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_01_fastLink.qmd
@@ -85,7 +85,7 @@ The APS data set was loaded for processing.
 
 ```{r}
 aps <- readRDS(here("data","DETECT Shared GRAs","aps_cleaning",
-                             "aps_01.rds"))
+                             "aps_02.rds"))
 ```
 
 ## Functions

--- a/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
@@ -173,6 +173,12 @@ aps <- readRDS(here("data","DETECT Shared GRAs","aps_cleaning",
          )
 ```
 
+The original APS Source ID Modification Map was loaded for processing.
+
+```{r}
+aps_source_map_original <- readRDS(here("data","DETECT Shared GRAs", "aps_cleaning","aps_id_replacement_map.rds"))
+```
+
 ## Functions
 
 ### Unique Value Summary
@@ -5076,6 +5082,24 @@ medstar <- left_join(medstar, full_pattern, by='ms_id') %>%
 aps <- left_join(aps, full_pattern, by='aps_person_id') %>%
   relocate('id', 'aps_person_id') %>%
   select(-c('ms_id'))
+```
+
+# Finalizing APS Subject ID Revision Maps
+
+We checked to ensure none of the new APS Person ID revisions were present in the original APS Subject ID revision map.
+
+```{r}
+colnames(aps_source_map_original)[1] <- "old_id"
+
+sum(aps_source_map_original$new_id %in% aps_source_map$old_id)
+sum(aps_source_map_original$old_id %in% aps_source_map$new_id)
+sum(aps_source_map_original$old_id %in% aps_source_map$old_id)
+```
+
+We appended the original APS Source ID revision map to our newly created revision map.
+
+```{r}
+aps_source_map <- rbind(aps_source_map, aps_source_map_original)
 ```
 
 # Saving and Exporting Data

--- a/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
@@ -5120,7 +5120,8 @@ saveRDS(full_pattern, here("data","DETECT Shared GRAs","merge_aps_medstar",
 We exported our revised source data sets.
 
 ```{r}
-saveRDS(medstar, here("data","DETECT Shared GRAs","medstar_02.rds"))
+saveRDS(medstar, here("data","DETECT Shared GRAs", "medstar_cleaning",
+                      "medstar_02.rds"))
 
-saveRDS(aps, here("data","DETECT Shared GRAs","aps_03.rds"))
+saveRDS(aps, here("data","DETECT Shared GRAs", "aps_cleaning", "aps_03.rds"))
 ```

--- a/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
@@ -5108,13 +5108,13 @@ We exported our maps, both for revising the source data set Subject IDs but also
 
 ```{r}
 saveRDS(aps_source_map, here("data","DETECT Shared GRAs","merge_aps_medstar",
-                             "aps_id_revision_pattern_01"))
+                             "aps_id_revision_pattern_01.rds"))
 
 saveRDS(ms_source_map, here("data","DETECT Shared GRAs","merge_aps_medstar",
-                             "medstar_id_revision_pattern_01"))
+                             "medstar_id_revision_pattern_01.rds"))
 
 saveRDS(full_pattern, here("data","DETECT Shared GRAs","merge_aps_medstar",
-                             "aps_medstar_full_map_01"))
+                             "aps_medstar_full_subjid_map_01.rds"))
 ```
 
 We exported our revised source data sets.

--- a/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
@@ -167,7 +167,7 @@ The APS data set was loaded for processing.
 
 ```{r}
 aps <- readRDS(here("data","DETECT Shared GRAs","aps_cleaning",
-                             "aps_01.rds")
+                             "aps_02.rds")
                ) %>%
     mutate(pt_dob = as.character(pt_dob)
          )
@@ -5098,5 +5098,5 @@ We exported our revised source data sets.
 ```{r}
 saveRDS(medstar, here("data","DETECT Shared GRAs","medstar_02.rds"))
 
-saveRDS(aps, here("data","DETECT Shared GRAs","aps_02.rds"))
+saveRDS(aps, here("data","DETECT Shared GRAs","aps_03.rds"))
 ```

--- a/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_02_group_ids.qmd
@@ -144,7 +144,6 @@ editor: visual
 
 library(tidyverse)
 library(here)
-library(fastLink)
 ```
 
 ## Data Imports

--- a/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
@@ -10,64 +10,69 @@ editor: visual
 
     -   5,490 MedStar Responses
     -   4,188 APS Intakes corresponding to 3,398 Case Numbers
-    
+
 -   The APS Data Set was filtered to reduce search space.
 
     -   Intakes were filtered to only include Intakes that occured between February 1, 2017 and 10 days after February 28, 2018 (March 08, 2018)
         -   This reduced the APS data set to 2,302 Intakes across 1,811 Case Numbers and 1,335 subjects
-     -   Intakes were filtered to only include Intakes that occured after the earliest MedStar Response for a subject.
-        -   This reduced the APS data set to 1,747 Intakes across 1,376 Case Numbers and 1,064 subjects 
+    -   Intakes were filtered to only include Intakes that occured after the earliest MedStar Response for a subject. - This reduced the APS data set to 1,747 Intakes across 1,376 Case Numbers and 1,064 subjects
     -   Intakes were filtered to only include Intakes that had a reporter of "Health Care Providers/Staff", "Health Care Providers/Staff -- EMS/EMT", "Anonymous", "Community Agencies/Organizations", or a missing value
         -   This reduced the APS data set to 1,104 Intakes across 923 Case Numbers and 779 subjects
 
 -   The MedStar Data Set was filtered to only include subjects still present in the filtered APS Data Set
 
-        -   This reduced the MedStar data set to 3,010 Responses across 779 subjects
-        
+    ```         
+    -   This reduced the MedStar data set to 3,010 Responses across 779 subjects
+    ```
+
 -   Initial matches were made from the APS Data Set using a 72 hour window between APS Intake and MedStar Response; this produced 487 pairs, representing 462 APS Case Numbers and 422 Subjects and included the manual verification of entries in both data sets across 172 Subject IDs.
 
-        -   Subjects with a single APS Intake were assessed for pairs; 576 Subjects were assessed
-              -   This produced 269 pairs, across 269 APS Case Numbers and 269 Subjects
-              -   20 Subjects were manually checked, as they were duplicated in the automatic processing
-        -   Remaining APS Case Numbers with a single APS Intake were assessed for pairs; 413 Subjects across 522 APS Case Numbers were assessed
-              -   This produced 93 novel pairs, across 92 novel APS Case Numbers and 66 novel Subjects 
-              -   30 Subjects were manually checked, as they were duplicated in the automatic processing
-        -   Remaining APS Intakes that were missing a reporter type were assessed for pairs; 30 Subjects, each with a single Case Number and Intake, were assesed
-              -   This produced 2 novel pairs, across 2 novel APS Case Numbers and 1 novel Subject
-              -   All 30 Subjects were manually checked
-        -   Remaining APS Intakes with an Anonymous reporter were assessed for pairs; 31 Subjects, across 35 APS Case Numbers and 35 Intakes, were assessed
-              -   This produced 4 novel pairs, across 4 novel APS Case Numbers and 4 novel Subjects 
-              -   All 31 Subjects were manually checked
-        -   Remaining APS Intakes with an explicit EMS/EMT reporter were assessed for pairs; 78 Subjects, across 80 APS Case Numbers and 101 Intakes, were assessed
-              -   This produced 85 novel pairs, across 68 novel APS Case Numbers and 61 novel Subjects 
-              -   22 Subjects were manually checked, as they were duplicated in the automatic processing
-        -   Remaining APS Intakes with a Community Agency/Organization reporter were assessed for pairs; 157 Subjects, across 166 APS Case Numbers and 173 Intakes, were assessed
-              -   This produced 5 novel pairs, across 5 novel APS Case Numbers and 2 novel Subjects 
-              -   The 4 Subjects that were paired in automatic processing were manually checked
-        -   Remaining APS Intakes with a Health Care reporter, but not explicitly EMS/EMT, were assesed for pairs; 210 Subjects, across 225 APS Case Numbers and 247 Intakes, were assessed
-              -   This produced 28 novel pairs, across 22 novel APS Case Numbers and 19 novel Subjects 
-              -   The 22 Subjects that were paired in automatic processing were manually checked
-        -   All Remaining Unmatched APS Intakes with an EMS/EMT reporter were manually assessed for pairs; 13 Subjects were assessed
-              -   This produced 1 novel pair, across 1 novel APS Case Number and 0 novel Subjects 
+    ```         
+    -   Subjects with a single APS Intake were assessed for pairs; 576 Subjects were assessed
+          -   This produced 269 pairs, across 269 APS Case Numbers and 269 Subjects
+          -   20 Subjects were manually checked, as they were duplicated in the automatic processing
+    -   Remaining APS Case Numbers with a single APS Intake were assessed for pairs; 413 Subjects across 522 APS Case Numbers were assessed
+          -   This produced 93 novel pairs, across 92 novel APS Case Numbers and 66 novel Subjects 
+          -   30 Subjects were manually checked, as they were duplicated in the automatic processing
+    -   Remaining APS Intakes that were missing a reporter type were assessed for pairs; 30 Subjects, each with a single Case Number and Intake, were assesed
+          -   This produced 2 novel pairs, across 2 novel APS Case Numbers and 1 novel Subject
+          -   All 30 Subjects were manually checked
+    -   Remaining APS Intakes with an Anonymous reporter were assessed for pairs; 31 Subjects, across 35 APS Case Numbers and 35 Intakes, were assessed
+          -   This produced 4 novel pairs, across 4 novel APS Case Numbers and 4 novel Subjects 
+          -   All 31 Subjects were manually checked
+    -   Remaining APS Intakes with an explicit EMS/EMT reporter were assessed for pairs; 78 Subjects, across 80 APS Case Numbers and 101 Intakes, were assessed
+          -   This produced 85 novel pairs, across 68 novel APS Case Numbers and 61 novel Subjects 
+          -   22 Subjects were manually checked, as they were duplicated in the automatic processing
+    -   Remaining APS Intakes with a Community Agency/Organization reporter were assessed for pairs; 157 Subjects, across 166 APS Case Numbers and 173 Intakes, were assessed
+          -   This produced 5 novel pairs, across 5 novel APS Case Numbers and 2 novel Subjects 
+          -   The 4 Subjects that were paired in automatic processing were manually checked
+    -   Remaining APS Intakes with a Health Care reporter, but not explicitly EMS/EMT, were assesed for pairs; 210 Subjects, across 225 APS Case Numbers and 247 Intakes, were assessed
+          -   This produced 28 novel pairs, across 22 novel APS Case Numbers and 19 novel Subjects 
+          -   The 22 Subjects that were paired in automatic processing were manually checked
+    -   All Remaining Unmatched APS Intakes with an EMS/EMT reporter were manually assessed for pairs; 13 Subjects were assessed
+          -   This produced 1 novel pair, across 1 novel APS Case Number and 0 novel Subjects 
+    ```
 
 -   Further matches were made from the MedStar data set.
 
-        -   Remaining MedStar Responses that indicated an APS Report had been made were assessed for pairs; 11 Subjects across 10 Responses were assessed
-              -   All 11 Subjects were manually checked
-              -   This produced 1 novel pair, without an additional APS Case Number or Subject
-        -   Remaining Subjects with a single unmatched or unchecked MedStar Response were assessed for pairs; 117 Subjects across 117 Responses were assessed
-              -   All 117 Subjects were manually checked
-              -   This produced no pairs
-        -   Remaining MedStar Responses that were missing an indication of if an APS Report had been made or not were assessed for pairs; 121 Subjects across 236 Responses were assessed
-              -   The 3 Subjects that were paired in automatic processing were manually checked
-              -   This produced 4 novel pairs, without an additional APS Case Number or Subject
-              
+    ```         
+    -   Remaining MedStar Responses that indicated an APS Report had been made were assessed for pairs; 11 Subjects across 10 Responses were assessed
+          -   All 11 Subjects were manually checked
+          -   This produced 1 novel pair, without an additional APS Case Number or Subject
+    -   Remaining Subjects with a single unmatched or unchecked MedStar Response were assessed for pairs; 117 Subjects across 117 Responses were assessed
+          -   All 117 Subjects were manually checked
+          -   This produced no pairs
+    -   Remaining MedStar Responses that were missing an indication of if an APS Report had been made or not were assessed for pairs; 121 Subjects across 236 Responses were assessed
+          -   The 3 Subjects that were paired in automatic processing were manually checked
+          -   This produced 4 novel pairs, without an additional APS Case Number or Subject
+    ```
+
 -   The remaining 11 unpaired MedStar Responses across 10 Subjects which indicated an APS Report had been made were manually rechecked; this produced no pairs
 
 -   The remaining 29 APS Intakes across 28 APS Case Numbers and Subjects which indicated an EMS/EMT reporter were manually rechecked; this produced 2 corrections, and the loss of 1 APS Case Number
 
 -   The final map contained 492 pairs, representing 461 APS Case Numbers and 422 Subjects
-         
+
 # Imports
 
 ## Library Imports
@@ -190,7 +195,6 @@ point_map_aps <- function(t_id, t_aps, t_ms){
 }
 ```
 
-
 # Initiation of Data Maps
 
 We initiated several of the data frames we would use to collect the results of our processing.
@@ -256,7 +260,7 @@ There were only 305 observations in the MedStar data set with a DETECT tool resp
 get_unique_value_summary(medstar, 'detect_report_made')
 ```
 
-There were no observations missing data indicating that an APS report was made that also contained an APS Report Number. There were two observations, each representing a single MedStar Subject ID and Group ID, which indicated an APS report was *not* made, but provided an APS Report Number. 
+There were no observations missing data indicating that an APS report was made that also contained an APS Report Number. There were two observations, each representing a single MedStar Subject ID and Group ID, which indicated an APS report was *not* made, but provided an APS Report Number.
 
 ```{r}
 checking <- medstar %>%
@@ -312,7 +316,7 @@ medstar_missing <- unique(checking$id)
 
 Of the 269 Group IDs with at least one MedStar record indicating an APS report was made, 176 Group IDs (65.43%) contained additional observations which indicated that *no* APS report was made and 61 Group IDs (22.68%) contained additional observations with missing data regarding an APS report. There were 54 Group IDs (20.07%) with observations indicating an APS report was made, indicating *no* APS report was made, and missing data regarding an APS report being made.
 
-Of the 1767 Group IDs with at least one MedStar record indicating that *no* APS report was made, 359 Group IDs (20.32%) also referenced observations missing data indicating if an APS report was made. 
+Of the 1767 Group IDs with at least one MedStar record indicating that *no* APS report was made, 359 Group IDs (20.32%) also referenced observations missing data indicating if an APS report was made.
 
 ```{r}
 sum(medstar_yes %in% medstar_no)
@@ -383,7 +387,7 @@ nrow(ms_earliest)
 length(unique(ms_earliest$id))
 ```
 
-We excluded any Intakes that occurred prior to the earliest MedStar Response for each subject. This reduced our APS data set to 1,747 Intakes across 1,376 APS Case Numbers and 1,064 APS Person IDs. 
+We excluded any Intakes that occurred prior to the earliest MedStar Response for each subject. This reduced our APS data set to 1,747 Intakes across 1,376 APS Case Numbers and 1,064 APS Person IDs.
 
 ```{r}
 aps <- aps %>%
@@ -591,7 +595,6 @@ dup_ids <- dup_ids %>%
   select(-c(ms_epcr_row))
 ```
 
-
 We appended the results of this processing to our processing data frames.
 
 ```{r}
@@ -750,7 +753,7 @@ sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
 temp_map <- rbind(temp_map, point_map)
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Person ID, APS Case Number, or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Person ID, APS Case Number, or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -873,7 +876,7 @@ for (i in 1:length(checking_ids)){
 }
 ```
 
-Of the 30 APS Person ID Values checked, 27 APS Person IDs appeared to lack a potentially valid match in the MedStar data set (90.00% failure rate). None of the 3 potential pairs identified in the initial matching appeared to be valid. There were 3 APS Intakes, representing 3 APS Case Numbers and 3 APS Person IDs, which had manual matches made. 
+Of the 30 APS Person ID Values checked, 27 APS Person IDs appeared to lack a potentially valid match in the MedStar data set (90.00% failure rate). None of the 3 potential pairs identified in the initial matching appeared to be valid. There were 3 APS Intakes, representing 3 APS Case Numbers and 3 APS Person IDs, which had manual matches made.
 
 ```{r}
 temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
@@ -909,7 +912,7 @@ point_map <- point_map %>%
 temp_map <- rbind(temp_map, point_map)
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -1029,7 +1032,7 @@ point_map <- rbind(point_map, point_map_aps(945, 6205, 26841))
 point_map <- rbind(point_map, point_map_aps(1513, 14788, 5299))
 ```
 
-We verified that these particular APS Case Numbers and Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+We verified that these particular APS Case Numbers and Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% temp_map$id)
@@ -1051,7 +1054,7 @@ dup_ids <- dup_ids %>%
   filter(!(id %in% temp_map$id))
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -1188,7 +1191,7 @@ for (i in 1:length(checking_ids)){
 }
 ```
 
-Of the 22 APS Person ID values checked, all appeared to have at least one valid match within the MedStar data set. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set. 
+Of the 22 APS Person ID values checked, all appeared to have at least one valid match within the MedStar data set. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set.
 
 Of note, there were 2 APS Person IDs that required the removal then manual addition of an MedStar-APS pair, as both the APS Intake and MedStar Response had both a true-match and false-match in the section-wise map. There were also 7 APS Person IDs where there were multiple APS Intakes matched to a single MedStar Response; on inspection, it appeared that these intakes may have represented two EMS personnel (possibly both EMS partners) making separate reports relating to the same call. For these intakes, only the first matching intake was kept.
 
@@ -1234,7 +1237,7 @@ point_map <- rbind(point_map, point_map_aps(1555, 15796, 29665))
 point_map <- rbind(point_map, point_map_aps(1589, 16878, 31176))
 ```
 
-We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% temp_map$id)
@@ -1257,7 +1260,7 @@ dup_ids <- dup_ids %>%
   filter(!(id %in% temp_map$id))
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -1417,7 +1420,7 @@ point_map <- rbind(point_map, point_map_aps(1634, 17968, 27507))
 point_map <- rbind(point_map, point_map_aps(1634, 17969, 31024))
 ```
 
-We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% intake_response_pairs$id)
@@ -1432,7 +1435,7 @@ We appended our manually identified pairs to our section-wise map.
 temp_map <- rbind(temp_map, point_map)
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -1603,7 +1606,7 @@ point_map <- rbind(point_map, point_map_aps(1128, 7017, 7411))
 point_map <- rbind(point_map, point_map_aps(1962, 17918, 7107))
 ```
 
-We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% intake_response_pairs$id)
@@ -1623,7 +1626,7 @@ dup_ids <- dup_ids %>%
     )
 ```
 
-We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records.
 
 ```{r}
 sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
@@ -1702,7 +1705,7 @@ point_map <- tibble("id" = c(), "aps_case_num" = c(),
 point_map <- rbind(point_map, point_map_aps(770, 7684, 15246))
 ```
 
-We verified that this particular APS Intake was not otherwise represented in our overall MedStar Response-APS Intake pair map. 
+We verified that this particular APS Intake was not otherwise represented in our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% intake_response_pairs$id)
@@ -1716,7 +1719,6 @@ We appended the results of this processing to our processing data frames.
 ```{r}
 intake_response_pairs <- rbind(intake_response_pairs, point_map)
 ```
-
 
 ### Updates from Manually Checked ID List
 
@@ -1733,7 +1735,6 @@ manual_aps <- aps %>%
 unmatched_aps_intakes <- rbind(unmatched_aps_intakes, manual_aps) %>%
   distinct()
 ```
-
 
 ## MedStar
 
@@ -1797,7 +1798,7 @@ point_map <- rbind(point_map, point_map_aps(824, 9482, 19998))
 manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
 ```
 
-We verified that these particular MedStar Responses were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+We verified that these particular MedStar Responses were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map.
 
 ```{r}
 sum(point_map$id %in% intake_response_pairs$id)
@@ -1809,7 +1810,6 @@ sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
 ```{r}
 intake_response_pairs <- rbind(intake_response_pairs, point_map)
 ```
-
 
 ### Subjects With a Single Remaining Response
 
@@ -1852,7 +1852,6 @@ manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
 
 unmatched_ms_responses <- rbind(unmatched_ms_responses, dup_ids)
 ```
-
 
 ### Responses Missing an Indication of a Report Being Made
 
@@ -1916,7 +1915,7 @@ length(unique(temp_map$aps_row))
 length(unique(temp_map$ms_epcr_row))
 ```
 
-These 3 MedStar Subject IDs were manually verified. 
+These 3 MedStar Subject IDs were manually verified.
 
 ```{r}
 checking_ids <- unique(temp_map$id)
@@ -1930,7 +1929,7 @@ for (i in 1:length(checking_ids)){
 }
 ```
 
-There was a single mismatched APS Intake, which was adjusted to reference a more potentially valid MedStar Response. The remaining pairs appeared potentially valid, without additional potential pairs identified. 
+There was a single mismatched APS Intake, which was adjusted to reference a more potentially valid MedStar Response. The remaining pairs appeared potentially valid, without additional potential pairs identified.
 
 ```{r}
 temp_map <- rbind(temp_map[temp_map$aps_row != 11603,], 
@@ -1938,8 +1937,6 @@ temp_map <- rbind(temp_map[temp_map$aps_row != 11603,],
 
 manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
 ```
-
-
 
 ```{r}
 checking_ids <- setdiff(unique(checking$id), checking_ids)
@@ -2050,7 +2047,6 @@ intake_response_pairs <- rbind(
 )
 ```
 
-
 # Map Verification and Application
 
 ## Verification
@@ -2134,7 +2130,10 @@ medstar <- medstar %>%
   add_column(aps_person_id = NA_integer_, aps_case_num = NA_integer_, 
              aps_row = NA_integer_)
 
-medstar <- rows_update(medstar, intake_response_pairs, by = "ms_epcr_row") %>%
+medstar <- rows_update(medstar, intake_response_pairs, by = "ms_epcr_row") 
+medstar <- rows_update(medstar, merge_pattern %>%
+                         select(id, aps_person_id) %>%
+                         distinct(), by = "id", unmatched = "ignore") %>%
   relocate(id, ms_id, aps_person_id, aps_case_num, aps_row, ms_epcr_row, 
            ms_comp_row)
 
@@ -2142,7 +2141,10 @@ aps <- aps %>%
   add_column(ms_id = NA_integer_, ms_epcr_row = NA_integer_, 
              ms_comp_row = NA_integer_)
 
-aps <- rows_update(aps, intake_response_pairs, by = "aps_row") %>%
+aps <- rows_update(aps, intake_response_pairs, by = "aps_row") 
+aps <- rows_update(aps, merge_pattern %>%
+                     select(id, ms_id) %>%
+                     distinct(), by = "id", unmatched = "ignore") %>%
     relocate(id, ms_id, aps_person_id, aps_case_num, aps_row, ms_epcr_row, 
            ms_comp_row)
 ```

--- a/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
@@ -2092,6 +2092,6 @@ We saved and exported our map for later use.
 ```{r}
 saveRDS(intake_response_pairs, 
         here("data","DETECT Shared GRAs", "merge_aps_medstar", 
-             "medstar_aps_row_pair_map_01.rds"))
+             "medstar_aps_full_row_map_01.rds"))
 ```
 

--- a/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
@@ -1,0 +1,2097 @@
+---
+title: "Analysis"
+format: html
+editor: visual
+---
+
+# Summary
+
+-   There were 1,967 Subjects present in both the APS and MedStar data set.
+
+    -   5,490 MedStar Responses
+    -   4,188 APS Intakes corresponding to 3,398 Case Numbers
+    
+-   The APS Data Set was filtered to reduce search space.
+
+    -   Intakes were filtered to only include Intakes that occured between February 1, 2017 and 10 days after February 28, 2018 (March 08, 2018)
+        -   This reduced the APS data set to 2,302 Intakes across 1,811 Case Numbers and 1,335 subjects
+     -   Intakes were filtered to only include Intakes that occured after the earliest MedStar Response for a subject.
+        -   This reduced the APS data set to 1,747 Intakes across 1,376 Case Numbers and 1,064 subjects 
+    -   Intakes were filtered to only include Intakes that had a reporter of "Health Care Providers/Staff", "Health Care Providers/Staff -- EMS/EMT", "Anonymous", "Community Agencies/Organizations", or a missing value
+        -   This reduced the APS data set to 1,104 Intakes across 923 Case Numbers and 779 subjects
+
+-   The MedStar Data Set was filtered to only include subjects still present in the filtered APS Data Set
+
+        -   This reduced the MedStar data set to 3,010 Responses across 779 subjects
+        
+-   Initial matches were made from the APS Data Set using a 72 hour window between APS Intake and MedStar Response; this produced 487 pairs, representing 462 APS Case Numbers and 422 Subjects and included the manual verification of entries in both data sets across 172 Subject IDs.
+
+        -   Subjects with a single APS Intake were assessed for pairs; 576 Subjects were assessed
+              -   This produced 269 pairs, across 269 APS Case Numbers and 269 Subjects
+              -   20 Subjects were manually checked, as they were duplicated in the automatic processing
+        -   Remaining APS Case Numbers with a single APS Intake were assessed for pairs; 413 Subjects across 522 APS Case Numbers were assessed
+              -   This produced 93 novel pairs, across 92 novel APS Case Numbers and 66 novel Subjects 
+              -   30 Subjects were manually checked, as they were duplicated in the automatic processing
+        -   Remaining APS Intakes that were missing a reporter type were assessed for pairs; 30 Subjects, each with a single Case Number and Intake, were assesed
+              -   This produced 2 novel pairs, across 2 novel APS Case Numbers and 1 novel Subject
+              -   All 30 Subjects were manually checked
+        -   Remaining APS Intakes with an Anonymous reporter were assessed for pairs; 31 Subjects, across 35 APS Case Numbers and 35 Intakes, were assessed
+              -   This produced 4 novel pairs, across 4 novel APS Case Numbers and 4 novel Subjects 
+              -   All 31 Subjects were manually checked
+        -   Remaining APS Intakes with an explicit EMS/EMT reporter were assessed for pairs; 78 Subjects, across 80 APS Case Numbers and 101 Intakes, were assessed
+              -   This produced 85 novel pairs, across 68 novel APS Case Numbers and 61 novel Subjects 
+              -   22 Subjects were manually checked, as they were duplicated in the automatic processing
+        -   Remaining APS Intakes with a Community Agency/Organization reporter were assessed for pairs; 157 Subjects, across 166 APS Case Numbers and 173 Intakes, were assessed
+              -   This produced 5 novel pairs, across 5 novel APS Case Numbers and 2 novel Subjects 
+              -   The 4 Subjects that were paired in automatic processing were manually checked
+        -   Remaining APS Intakes with a Health Care reporter, but not explicitly EMS/EMT, were assesed for pairs; 210 Subjects, across 225 APS Case Numbers and 247 Intakes, were assessed
+              -   This produced 28 novel pairs, across 22 novel APS Case Numbers and 19 novel Subjects 
+              -   The 22 Subjects that were paired in automatic processing were manually checked
+        -   All Remaining Unmatched APS Intakes with an EMS/EMT reporter were manually assessed for pairs; 13 Subjects were assessed
+              -   This produced 1 novel pair, across 1 novel APS Case Number and 0 novel Subjects 
+
+-   Further matches were made from the MedStar data set.
+
+        -   Remaining MedStar Responses that indicated an APS Report had been made were assessed for pairs; 11 Subjects across 10 Responses were assessed
+              -   All 11 Subjects were manually checked
+              -   This produced 1 novel pair, without an additional APS Case Number or Subject
+        -   Remaining Subjects with a single unmatched or unchecked MedStar Response were assessed for pairs; 117 Subjects across 117 Responses were assessed
+              -   All 117 Subjects were manually checked
+              -   This produced no pairs
+        -   Remaining MedStar Responses that were missing an indication of if an APS Report had been made or not were assessed for pairs; 121 Subjects across 236 Responses were assessed
+              -   The 3 Subjects that were paired in automatic processing were manually checked
+              -   This produced 4 novel pairs, without an additional APS Case Number or Subject
+              
+-   The remaining 11 unpaired MedStar Responses across 10 Subjects which indicated an APS Report had been made were manually rechecked; this produced no pairs
+
+-   The remaining 29 APS Intakes across 28 APS Case Numbers and Subjects which indicated an EMS/EMT reporter were manually rechecked; this produced 2 corrections, and the loss of 1 APS Case Number
+
+-   The final map contained 492 pairs, representing 461 APS Case Numbers and 422 Subjects
+         
+# Imports
+
+## Library Imports
+
+```{r}
+#| message: false
+#| warning: false
+
+library(tidyverse)
+library(here)
+library(lubridate)
+```
+
+## Data Imports
+
+We imported the revised MedStar data set for processing.
+
+```{r}
+medstar <- readRDS(here("data","DETECT Shared GRAs", "medstar_cleaning",
+                        "medstar_02.rds"))
+```
+
+We imported the revised APS data set for processing.
+
+```{r}
+aps <- readRDS(here("data","DETECT Shared GRAs", "aps_cleaning", "aps_04.rds"))
+```
+
+We imported the Group ID merge pattern for processing.
+
+```{r}
+merge_pattern <- readRDS(here("data","DETECT Shared GRAs","merge_aps_medstar",
+                              "aps_medstar_full_map_01"))
+```
+
+## Functions
+
+### Unique Value Summary
+
+A function written in a previous cleaning document was imported. It was written to display counts of each unique observations within a selection of columns.
+
+```{r}
+get_unique_value_summary <- function(df,cols){
+  
+  # Input: 
+  #     df (data frame) - original source data frame
+  #     cols (list) - list of target column names as strings
+  # Output:
+  #     unique_summary (data frame) - summary counts of each unique value in
+  #           each of the target columns
+  
+  # Get list of unique values in all target columns
+  
+  val <- unique(as.factor(as.vector(as.matrix(df[cols]))))
+  
+  # Initialize output data frame with unique value row
+  
+  unique_summary <- data.frame("value"=val)
+  
+  # Get counts of unique values in original data frame
+  
+  for (i in cols){
+    
+    # utilizes table to get summary count of each column
+    
+    table <- as.data.frame(table(df[i]))
+    
+    # sets column names to "value" and "freq"
+    
+  colnames(table) <- c("value","freq")
+  
+    # adds count of missing values in each column
+  
+  table<- add_row(table, value = NA, freq = sum(is.na(df[i])))
+  
+    # readjusts names of columns to "value" and the name of the target column
+  
+  colnames(table) <- c("value",i)
+  
+    # joins table's summary counts to complete the count values
+  
+    unique_summary <- left_join(unique_summary,table, by="value")
+  }
+  
+  # returns completed, but unordered, data frame
+  
+  unique_summary
+  }
+```
+
+### Point-Map Additions
+
+A convenience function was written to facilitate point-fix additions to the APS Intake - MedStar Response pairing map, using Group ID and row numbers.
+
+```{r}
+point_map_aps <- function(t_id, t_aps, t_ms){
+  #
+  # Generates a tibble for point-fix additions to the map connecting
+  # APS Intakes to MedStar Responses
+  #
+  # Input: 
+  #     t_id:             numeric. Group ID number of the pairing
+  #     t_aps:            numeric. APS Row Number associated with the APS
+  #                       intake of the pairing
+  #     t_ms:             numeric. MedStar ePCR Row Number associated with the
+  #                       MedStar EMS Response of the pairing
+  # Output:
+  #     temp_tibble:      tibble. Single row tibble in the format of the
+  #                       APS Intake - MedStar Response pairing map
+  
+  temp_tibble <- tibble('id' = t_id,
+                          # Pulls case number from the row
+                        'aps_case_num' = pull(
+                                aps[aps$aps_row == t_aps, 'aps_case_num']),
+                        'aps_row' = t_aps,
+                        'ms_epcr_row' = t_ms
+  )
+  
+  temp_tibble
+}
+```
+
+
+# Initiation of Data Maps
+
+We initiated several of the data frames we would use to collect the results of our processing.
+
+```{r}
+intake_response_pairs <- tibble(!!!c('id', 'aps_case_num', 
+                                     'aps_row', 'ms_epcr_row'), .rows = 0,
+                                .name_repair = ~ c('id', 'aps_case_num', 
+                                     'aps_row', 'ms_epcr_row')
+                                )
+  
+unmatched_aps_intakes <- tibble(!!!c('id', 'aps_case_num', 
+                                     'aps_row'), .rows = 0,
+                                .name_repair = ~ c('id', 'aps_case_num', 
+                                     'aps_row')
+                                )
+  
+unmatched_ms_responses <- tibble(!!!c('id', 'ms_epcr_row'), .rows = 0,
+                                .name_repair = ~ c('id', 'ms_epcr_row')
+                                )
+  
+manually_verified_ids <- c()
+```
+
+# Extracting Merge IDs
+
+We identified our target observations as those belonging to any Group ID which connected an APS Person ID and MedStar Subject ID, indicating that there were corresponding records matched across the data sets. We identified 1,967 such Group ID values.
+
+```{r}
+target_ids <- pull(merge_pattern %>% 
+  filter(!is.na(ms_id) & !(is.na(aps_person_id))) %>% 
+  select(id))
+```
+
+We reduced our source data sets to these observations. This reduced our MedStar data set to 5,490 observations corresponding 1,967 MedStar Subject IDs and Group IDs.
+
+```{r}
+medstar <- medstar %>%
+  filter(id %in% target_ids)
+
+nrow(medstar)
+length(unique(medstar$ms_id))
+length(unique(medstar$id))
+```
+
+This reduced our APS data set to 4,188 observations corresponding to 1,967 APS Person IDs and Group IDs, and 3,398 APS Case Numbers.
+
+```{r}
+aps <- aps %>%
+  filter(id %in% target_ids)
+
+nrow(aps)
+length(unique(aps$aps_person_id))
+length(unique(aps$aps_case_num))
+length(unique(aps$id))
+```
+
+## Observations Indicating an APS Report
+
+There were only 305 observations in the MedStar data set with a DETECT tool response indicating an APS report was made. There were an additional 4,262 observations that stated no report was made, and 797 observations missing data.
+
+```{r}
+get_unique_value_summary(medstar, 'detect_report_made')
+```
+
+There were no observations missing data indicating that an APS report was made that also contained an APS Report Number. There were two observations, each representing a single MedStar Subject ID and Group ID, which indicated an APS report was *not* made, but provided an APS Report Number. 
+
+```{r}
+checking <- medstar %>%
+  filter(is.na(detect_report_made) & !is.na(detect_report_num))
+
+nrow(checking)
+
+checking <- medstar %>%
+  filter(detect_report_made != "YES" & !is.na(detect_report_num))
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+The 305 observations that indicated an APS Report was made corresponded to 269 MedStar Subject IDs and Group IDs.
+
+```{r}
+checking <- medstar %>%
+  filter(detect_report_made == "YES")
+
+nrow(checking)
+length(unique(checking$ms_id))
+length(unique(checking$id))
+
+medstar_yes <- unique(checking$id)
+```
+
+The 4262 observations that indicated an APS Report was *not* made corresponded to 1767 MedStar Subject IDs and Group IDs.
+
+```{r}
+checking <- medstar %>%
+  filter(detect_report_made == "NO")
+
+nrow(checking)
+length(unique(checking$ms_id))
+length(unique(checking$id))
+
+medstar_no <- unique(checking$id)
+```
+
+The 797 observations missing data indicating if an APS Report was made corresponded to 366 MedStar Subject IDs and Group IDs.
+
+```{r}
+checking <- medstar %>%
+  filter(is.na(detect_report_made))
+
+nrow(checking)
+length(unique(checking$ms_id))
+length(unique(checking$id))
+
+medstar_missing <- unique(checking$id)
+```
+
+Of the 269 Group IDs with at least one MedStar record indicating an APS report was made, 176 Group IDs (65.43%) contained additional observations which indicated that *no* APS report was made and 61 Group IDs (22.68%) contained additional observations with missing data regarding an APS report. There were 54 Group IDs (20.07%) with observations indicating an APS report was made, indicating *no* APS report was made, and missing data regarding an APS report being made.
+
+Of the 1767 Group IDs with at least one MedStar record indicating that *no* APS report was made, 359 Group IDs (20.32%) also referenced observations missing data indicating if an APS report was made. 
+
+```{r}
+sum(medstar_yes %in% medstar_no)
+sum(medstar_yes %in% medstar_missing)
+sum(medstar_yes[medstar_yes %in% medstar_no] %in% medstar_missing)
+sum(medstar_no %in% medstar_missing)
+```
+
+# APS Filtering
+
+## Filtering by Dates
+
+As the MedStar Data was collected between February 2017 and February 2018, we were not interested in APS Case Numbers closed prior to this period, or Intakes made after this period.
+
+We utilized the lubridate package and tidyverse to define our study period interval. We tested to ensure that dates were interpreted appropriately. We similarly defined a range of values for individual APS Intakes to include any intakes that occurred during the study period, or 10 days after its conclusion.
+
+```{r}
+start_date <- date("2017-02-01")
+end_date <- date("2018-02-28")
+
+study_period <- interval(start = start_date, end = end_date)
+study_intake_range <- interval(start = start_date, 
+                                       end = end_date + ddays(x = 10))
+
+date("2017-01-31") %within% study_period
+date("2017-02-01") %within% study_period
+date("2018-02-28") %within% study_period
+date("2018-03-01") %within% study_period
+```
+
+There were 1,886 APS Intakes/Rows, associated with 1,605 APS Case Numbers and 1,015 APS Person IDs, which were outside of the Study's Intake Range.
+
+```{r}
+checking <- aps %>%
+  filter (!(aps_intake_dt %within% study_intake_range))
+
+nrow(checking)
+length(unique(checking$aps_case_num))
+length(unique(checking$id))
+```
+
+We excluded the observations outside of the Study Intake Range. There were 2,302 APS Intakes remaining, associated with 1,811 APS Case Numbers and 1335 APS Person IDs.
+
+```{r}
+checking <- aps %>%
+  filter (aps_intake_dt %within% study_intake_range)
+
+nrow(checking)
+length(unique(checking$aps_case_num))
+length(unique(checking$id))
+
+aps <- checking
+```
+
+## APS Intakes *After* Any Potential MedStar Response
+
+For an APS Intake to have a valid MedStar Response, the MedStar Response must precede the APS Intake. In order to filter by this metric, we isolated the single earliest MedStar Response for each subject within the MedStar data set.
+
+```{r}
+nrow(medstar)
+length(unique(medstar$id))
+
+ms_earliest <- medstar %>%
+  group_by(id) %>%
+  slice_min(order_by = response_dt, with_ties = FALSE) 
+
+nrow(ms_earliest)
+length(unique(ms_earliest$id))
+```
+
+We excluded any Intakes that occurred prior to the earliest MedStar Response for each subject. This reduced our APS data set to 1,747 Intakes across 1,376 APS Case Numbers and 1,064 APS Person IDs. 
+
+```{r}
+aps <- aps %>%
+  rowwise() %>% 
+  filter(aps_intake_dt > ms_earliest[ms_earliest$id==id,]$response_dt) %>%
+  ungroup()
+
+nrow(aps)
+length(unique(aps$aps_case_num))
+length(unique(aps$id))
+```
+
+## Observations Indicating a Health Care Reporter
+
+The APS data set contained flags indicating if there was an EMS/EMT or Healthcare reporter listed for the individual Intake Rows, for any intake in a Case Number, or for any intake for a single Subject. We identified five potential reporter types which may refer to EMS personnel: "Health Care Providers/Staff", "Health Care Providers/Staff -- EMS/EMT", "Anonymous", "Community Agencies/Organizations", or intakes missing a value for reporter type. Other reporter types, such as Law Enforcement, were likely to exclude EMS. There were 1,026 APS Intakes with one of these reporter types.
+
+```{r}
+potential_reporter_types <- c("Health Care Providers/Staff", 
+                              "Health Care Providers/Staff -- EMS/EMT", 
+                              "Anonymous", "Community Agencies/Organizations",
+                              NA_character_)
+```
+
+There were 643 remaining APS Intakes/Rows which did not include one of our identified Potential Reporter Types, associated with 561 APS Case Numbers and 460 APS Person IDs. These were most commonly associated with "Family Members and Relatives" (174 Intakes) and "Law Enforcement" (102 Intakes).
+
+```{r}
+checking <- aps %>%
+  filter(!(aps_reporter %in% potential_reporter_types))
+
+nrow(checking)
+length(unique(checking$aps_case_num))
+length(unique(checking$id))
+
+get_unique_value_summary(checking, 'aps_reporter') %>% 
+  arrange(aps_reporter)
+```
+
+We excluded the observations with a reporter type which was not likely to reference EMS. There were 1,104 Intakes/Rows which included one of our identified Potential Reporter Types, associated with 923 APS Case Numbers and 779 APS Person IDs. These were most commonly associated with "Health Care Providers/Staff" (466 Intakes) and "Health Care Providers/Staff -- EMS/EMT" (205 Intakes), followed by "Community Agencies/Organizations" (250 Intakes).
+
+```{r}
+checking <- aps %>%
+  filter(aps_reporter %in% potential_reporter_types)
+
+nrow(checking)
+length(unique(checking$aps_case_num))
+length(unique(checking$id))
+
+get_unique_value_summary(checking, 'aps_reporter') %>% 
+  arrange(aps_reporter)
+
+aps <- checking
+```
+
+# Determining Merge Matches
+
+After broad filtering, there were 779 Group IDs represented in the APS data set and 1,967 Group IDs represented in the MedStar data set. Of these, there were 779 Group IDs which continued to be represented in both data sets.
+
+```{r}
+aps_ids <- unique(aps$id)
+medstar_ids <- unique(medstar$id)
+final_ids <- aps_ids[aps_ids %in% medstar_ids]
+
+length(aps_ids)
+length(medstar_ids)
+length(final_ids)
+```
+
+These Group IDs represented 779 MedStar Subject IDs across 3,010 Responses/Rows in the MedStar data set, and 779 APS Person IDs across 923 Case Numbers and 1,104 Intakes/Rows in the APS data set.
+
+```{r}
+medstar <- medstar %>%
+  filter(id %in% final_ids)
+
+nrow(medstar)
+length(unique(medstar$id))
+
+aps <- aps %>%
+  filter(id %in% final_ids)
+
+nrow(aps)
+length(unique(aps$id))
+length(unique(aps$aps_case_num))
+```
+
+## APS
+
+### APS Person IDs with a Single Potential Intake
+
+There were 576 APS Person IDs which were represented with only one APS Case Number and Intake across the filtered APS data set.
+
+```{r}
+checking <- aps %>%
+  filter(!(duplicated(id)|duplicated(id, fromLast=TRUE)))
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+We assessed for potential matches in the MedStar data set. A 72 hour window from MedStar Response to APS Intake was selected for temporal proximity.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+
+manual <- manual %>%
+  filter( !(id %in% temp_map$id) )
+```
+
+This isolated 300 potential EMS Response - APS Intake pairs. There were 274 APS Person IDs and APS Case Numbers (47.57%) in this subset with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+```
+
+There were 20 APS Person IDs, which represented 20 APS Case Numbers, with multiple potential matches from the MedStar Data Set. Each of these Case Numbers was represented by a single Intake/Row. There were no additional APS Case Numbers associated with any of the duplicated IDs.
+
+```{r}
+dup_ids <- temp_map %>%
+  filter(duplicated(id)|duplicated(id, fromLast = TRUE))
+
+length(unique(dup_ids$id))
+length(unique(dup_ids$aps_case_num))
+
+dup_cases <- temp_map %>%
+  filter(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast = TRUE))
+
+nrow(dup_cases)
+length(unique(dup_cases$aps_case_num))
+
+dup_rows <- temp_map %>%
+  filter(duplicated(aps_row)|duplicated(aps_row, fromLast = TRUE))
+
+identical(dup_cases, dup_rows)
+
+length(unique(dup_ids[
+              !(dup_ids$aps_case_num %in% dup_cases$aps_case_num),
+              ]$aps_case_num
+              )
+       )
+```
+
+These 20 APS Person IDs were manually verified.
+
+```{r}
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 20 APS Person ID values checked, there were 15 with a match that appeared valid within the MedStar data set and 5 IDs with no matches. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set.
+
+```{r}
+dropping_ms_epcr_rows <- c(30698, 20850, 20817, 20721, 25828, 34777, 34811,
+                           34809, 34851, 10848, 30487, 8947, 27436, 2614, 2615,
+                           26559, 26560, 26371, 14586, 1794, 7653, 18536, 21029, 
+                           21200, 654, 13424, 31601, 22289, 22112, 11116, 11210)
+
+temp_map <- temp_map %>%
+  filter(!(ms_epcr_row %in% dropping_ms_epcr_rows))
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+dup_ids <- dup_ids %>%
+  filter(
+    !(aps_row %in% temp_map$aps_row)
+    ) %>%
+  select(-c(ms_epcr_row))
+```
+
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+### APS Case Numbers with a Single Potential Intake
+
+There were 522 remaining APS Case Numbers which were represented only once in the filtered APS data set, across 413 APS Person IDs.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num) )
+         ) %>%
+  filter(!(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast=TRUE)))
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+We assessed for potential matches in the MedStar data set. A 72 hour window from MedStar Response to APS Intake was selected for temporal proximity.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 124 potential EMS Response - APS Intake pairs. There were 67 APS Person IDs (16.22%) and 103 APS Case Numbers (19.73%) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+```
+
+There were 30 APS Person IDs, which represented 66 APS Case Numbers, represented more than once in our initial mapping. There were 14 Case Numbers, representing 12 APS Person IDs, with multiple potential matches from the MedStar Data Set. Each of these Case Numbers was represented by a single Intake/Row. There were no additional APS Case Numbers associated with any of the duplicated IDs. There were an additional 52 APS Case Numbers which were represented among the 30 APS Person IDs (which were duplicated), but only had a single potential match within a Case Number.
+
+```{r}
+dup_ids <- temp_map %>%
+  filter(duplicated(id)|duplicated(id, fromLast = TRUE))
+
+length(unique(dup_ids$id))
+length(unique(dup_ids$aps_case_num))
+
+dup_cases <- temp_map %>%
+  filter(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast = TRUE))
+
+nrow(dup_cases)
+length(unique(dup_cases$aps_case_num))
+length(unique(dup_cases$id))
+
+dup_rows <- temp_map %>%
+  filter(duplicated(aps_row)|duplicated(aps_row, fromLast = TRUE))
+
+identical(dup_cases, dup_rows)
+
+length(unique(dup_ids[
+              !(dup_ids$aps_case_num %in% dup_cases$aps_case_num),
+              ]$aps_case_num
+              )
+       )
+```
+
+These 30 APS Person IDs were manually verified.
+
+```{r}
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 30 APS Person ID values checked, only 1 APS Person ID (referencing two APS Case Numbers represented by a single Intake) appeared to lack any potentially valid match in the MedStar data set. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set. There were 3 APS Person IDs that experienced multiple APS Intakes matched with a single MedStar Response; resolution of these groups resulted in 5 APS Case Numbers and Intakes being confirmed to have no apparent potentially valid match in the MedStar data set.
+
+```{r}
+dropping_ms_epcr_rows <- c(5859, 17811, 34908, 11030, 20338, 26442, 1552, 23554,
+                           19908, 21802, 15737, 6830, 6844, 14709, 14813, 14734, 
+                           19903, 19909, 19904, 19777, 32065, 2326, 35279, 1399, 
+                           1389, 3486, 17279, 23986, 5072, 5058)
+
+dropping_aps_rows <- c(4445, 4446, 13175, 14498, 14499)
+
+temp_map <- temp_map %>%
+  filter( !((ms_epcr_row %in% dropping_ms_epcr_rows)|
+            (aps_row %in% dropping_aps_rows))
+          )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+dup_ids <- dup_ids %>%
+  filter(
+    !(aps_row %in% temp_map$aps_row)
+    ) %>%
+  select(-c(ms_epcr_row))
+```
+
+Of the 10 APS Person IDs that represented an additional 13 APS Case Numbers, the resolution of 3 of these APS Person IDs resulted in the identification of 3 APS Case Numbers and 4 APS Intakes with apparently valid matches in the MedStar data set. We verified that these particular APS Case Numbers and Intakes were not otherwise represented in our section-wise map, nor in our overall MedStar Response-APS Intake pair map.
+
+```{r}
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(44, 1184, 16995))
+point_map <- rbind(point_map, point_map_aps(1422, 12536, 21273))
+point_map <- rbind(point_map, point_map_aps(1541, 15432, 12431))
+point_map <- rbind(point_map, point_map_aps(1541, 15434, 13662))
+
+sum(point_map$id %in% temp_map$id)
+sum(point_map$aps_case_num %in% temp_map$aps_case_num)
+sum(point_map$aps_row %in% temp_map$aps_row)
+sum(point_map$ms_epcr_row %in% temp_map$ms_epcr_row)
+
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+
+temp_map <- rbind(temp_map, point_map)
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Person ID, APS Case Number, or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+### Remaining APS Case Numbers by Reporter Category
+
+There were 533 remaining APS Case Numbers across 475 APS Person IDs which had not yet been matched or manually checked.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         )
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+#### Missing Reporter Type
+
+There were 30 remaining APS Case Numbers, each with a single APS Person ID, with a missing value for Reporter Type in the intake.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(is.na(aps_reporter))
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 30 APS IDs were checked for matches.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 3 potential EMS Response - APS Intake pairs. There were 2 APS Person IDs and Case Numbers (6.67%) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+
+dup_ids <- manual
+```
+
+All 30 APS IDs were manually verified.
+
+```{r}
+checking_ids <- unique(checking$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 30 APS Person ID Values checked, 27 APS Person IDs appeared to lack a potentially valid match in the MedStar data set (90.00% failure rate). None of the 3 potential pairs identified in the initial matching appeared to be valid. There were 3 APS Intakes, representing 3 APS Case Numbers and 3 APS Person IDs, which had manual matches made. 
+
+```{r}
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(9, 302, 18975))
+point_map <- rbind(point_map, point_map_aps(189, 5033, 6085))
+point_map <- rbind(point_map, point_map_aps(1717, 14849, 35611))
+```
+
+We verified that these particular APS Case Numbers and Intakes were not otherwise represented in our overall MedStar Response-APS Intake pair map. We identified 2 APS Person IDs, 1 APS Case Number, 1 APS Row, and 1 MedStar ePCR Row which appeared to already be represented. These values were manually checked.
+
+```{r}
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+It was identified that there was a novel pairing for a unique APS Case Number associated with an APS Person ID already in the map, but the pairing was not already represented. The pairing for Group ID 9 was already represented, and thus eliminated from the section-wise temporary map.
+
+```{r}
+point_map <- point_map %>%
+  filter(!(aps_row %in% intake_response_pairs$aps_row))
+
+temp_map <- rbind(temp_map, point_map)
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+#### Anonymous Reporters
+
+There were 31 remaining APS Case Numbers, representing 35 APS Person IDs, with an Anonymous reporter.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(aps_reporter %in% potential_reporter_types[3])
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 31 APS IDs were checked for matches.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 2 potential EMS Response - APS Intake pairs. There were 2 APS Person IDs and Case Numbers (6.45%) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+
+dup_ids <- manual
+```
+
+All 31 APS IDs were manually verified.
+
+```{r}
+checking_ids <- unique(checking$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 31 APS Person ID values checked, 26 APS Person IDs appeared to lack a potentially valid match in the MedStar data set (83.87% failure rate). Both of the potential pairs identified in the initial matching appeared to be valid. There were an additional 2 APS Intakes, representing 2 APS Case Numbers and 2 APS Person IDs, which had manual matches found during verification.
+
+```{r}
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(945, 6205, 26841))
+point_map <- rbind(point_map, point_map_aps(1513, 14788, 5299))
+```
+
+We verified that these particular APS Case Numbers and Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% temp_map$id)
+sum(point_map$aps_case_num %in% temp_map$aps_case_num)
+sum(point_map$aps_row %in% temp_map$aps_row)
+sum(point_map$ms_epcr_row %in% temp_map$ms_epcr_row)
+
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+We appended our manually identified pairs to our section-wise map, and removed the entries from the list of unmatched APS Intakes.
+
+```{r}
+temp_map <- rbind(temp_map, point_map)
+dup_ids <- dup_ids %>%
+  filter(!(id %in% temp_map$id))
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+#### EMS/EMT Reporter
+
+There were 80 remaining APS Case Numbers, representing 78 APS Person IDs, with an EMS/EMT reporter.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(aps_reporter == potential_reporter_types[2])
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 78 APS IDs were checked for matches.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 104 potential EMS Response - APS Intake pairs. There were 64 APS Person IDs (82.05%) and 66 Case Numbers (82.50%) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+
+dup_ids <- manual
+checking_ids <- unique(checking$id)
+```
+
+There were 22 APS Person IDs, which represented 24 APS Case Numbers, represented more than once in our initial mapping. There were 21 Case Numbers, representing 21 APS Person IDs, with multiple potential matches from the MedStar Data Set. There were 19 APS Rows with more than one potential match identified in the MedStar data set. There were 3 additional APS Case Numbers associated with the duplicated IDs, which were represented by a single intake.
+
+```{r}
+dup_ids <- temp_map %>%
+  filter(duplicated(id)|duplicated(id, fromLast = TRUE))
+
+length(unique(dup_ids$id))
+length(unique(dup_ids$aps_case_num))
+
+dup_cases <- temp_map %>%
+  filter(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast = TRUE))
+
+nrow(dup_cases)
+length(unique(dup_cases$aps_case_num))
+length(unique(dup_cases$id))
+
+dup_rows <- temp_map %>%
+  filter(duplicated(aps_row)|duplicated(aps_row, fromLast = TRUE))
+
+identical(dup_cases, dup_rows)
+nrow(dup_cases) - length(unique(dup_cases$aps_row))
+
+length(unique(dup_ids[
+              !(dup_ids$aps_case_num %in% dup_cases$aps_case_num),
+              ]$aps_case_num
+              )
+       )
+```
+
+These 22 APS Person IDs were manually verified.
+
+```{r}
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 22 APS Person ID values checked, all appeared to have at least one valid match within the MedStar data set. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set. 
+
+Of note, there were 2 APS Person IDs that required the removal then manual addition of an MedStar-APS pair, as both the APS Intake and MedStar Response had both a true-match and false-match in the section-wise map. There were also 7 APS Person IDs where there were multiple APS Intakes matched to a single MedStar Response; on inspection, it appeared that these intakes may have represented two EMS personnel (possibly both EMS partners) making separate reports relating to the same call. For these intakes, only the first matching intake was kept.
+
+```{r}
+dropping_ms_epcr_rows <- c(31033, 30897, 15990, 15922, 25679, 11448, 14284,
+                           10822, 34002, 16037, 29665, 23255, 7802, 7932, 7875,
+                           7957, 7954, 31176)
+
+dropping_aps_rows <- c(5199, 7887, 8682, 10132, 10131, 12846, 14670, 15113)
+
+temp_map <- temp_map %>%
+  filter( !((ms_epcr_row %in% dropping_ms_epcr_rows)|
+            (aps_row %in% dropping_aps_rows))
+          )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+dup_ids <- dup_ids %>%
+  filter(
+    !(aps_row %in% temp_map$aps_row)
+    ) %>%
+  select(-c(ms_epcr_row))
+```
+
+In addition to the 2 APS Person IDs that required manual pairing to keep the valid pairs, there were an additional 8 APS Intakes, representing 6 APS Case Numbers (1 previously unrepresented) and 6 APS Person IDs, which had manual matches found during verification.
+
+```{r}
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(56, 1717, 32843))
+point_map <- rbind(point_map, point_map_aps(127, 3555, 15922))
+point_map <- rbind(point_map, point_map_aps(840, 9986, 20734))
+point_map <- rbind(point_map, point_map_aps(840, 9989, 25849))
+point_map <- rbind(point_map, point_map_aps(884, 11017, 8761))
+point_map <- rbind(point_map, point_map_aps(884, 11018, 9030))
+point_map <- rbind(point_map, point_map_aps(1416, 12266, 11448))
+point_map <- rbind(point_map, point_map_aps(1525, 15114, 12436))
+point_map <- rbind(point_map, point_map_aps(1555, 15796, 29665))
+point_map <- rbind(point_map, point_map_aps(1589, 16878, 31176))
+```
+
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% temp_map$id)
+sum(point_map$aps_case_num %in% temp_map$aps_case_num)
+sum(point_map$aps_row %in% temp_map$aps_row)
+sum(point_map$ms_epcr_row %in% temp_map$ms_epcr_row)
+
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+We appended our manually identified pairs to our section-wise map, and removed the entries from the list of unmatched APS Intakes.
+
+```{r}
+temp_map <- rbind(temp_map, point_map)
+
+dup_ids <- dup_ids %>%
+  filter(!(id %in% temp_map$id))
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Case Number or APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Case Number or APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+#### Community Agencies/Organizations Reporter
+
+There were 166 remaining APS Case Numbers, representing 157 APS Person IDs, with a Community Agency/Organization reporter.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(aps_reporter == potential_reporter_types[4])
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 157 APS IDs were checked for matches.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 5 potential EMS Response - APS Intake pairs. There were 4 APS Person IDs (97.45% failure rate) and APS Case Numbers (97.59% failure rate) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+
+dup_ids <- manual
+checking_ids <- unique(checking$id)
+```
+
+There was 1 APS Person ID, represented by 1 APS Case Number, that was represented more than once in our initial mapping. This APS Person ID appeared to reference a single APS Case Number with multiple Intakes, each of which was represented only once.
+
+```{r}
+dup_ids <- temp_map %>%
+  filter(duplicated(id)|duplicated(id, fromLast = TRUE))
+
+length(unique(dup_ids$id))
+length(unique(dup_ids$aps_case_num))
+
+dup_cases <- temp_map %>%
+  filter(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast = TRUE))
+
+nrow(dup_cases)
+length(unique(dup_cases$aps_case_num))
+length(unique(dup_cases$id))
+
+dup_rows <- temp_map %>%
+  filter(duplicated(aps_row)|duplicated(aps_row, fromLast = TRUE))
+
+identical(dup_cases, dup_rows)
+nrow(dup_cases) - length(unique(dup_cases$aps_row))
+
+length(unique(dup_ids[
+              !(dup_ids$aps_case_num %in% dup_cases$aps_case_num),
+              ]$aps_case_num
+              )
+       )
+```
+
+The 4 APS Person IDs in the initial mapping were verified.
+
+```{r}
+checking_ids <- unique(temp_map$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+None of the pairs in the initial mapping appeared to be accurate. However, there were 5 pairs which appeared to be valid, that were not otherwise matched.
+
+```{r}
+dup_ids <- temp_map %>%
+  select(-c(ms_epcr_row))
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(1099, 12456, 30496))
+point_map <- rbind(point_map, point_map_aps(1480, 14172, 24848))
+point_map <- rbind(point_map, point_map_aps(1594, 16966, 12481))
+point_map <- rbind(point_map, point_map_aps(1634, 17968, 27507))
+point_map <- rbind(point_map, point_map_aps(1634, 17969, 31024))
+```
+
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+We appended our manually identified pairs to our section-wise map.
+
+```{r}
+temp_map <- rbind(temp_map, point_map)
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+#### Health Care Provider/Staff Reporter
+
+There were 225 remaining APS Case Numbers, representing 210 APS Person IDs, with a Health Care Provider/Staff reporter that was not otherwise specified as EMS.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_case_num %in% intake_response_pairs$aps_case_num)|
+             (aps_case_num %in% unmatched_aps_intakes$aps_case_num)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(aps_reporter == potential_reporter_types[1])
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 210 APS IDs were checked for matches.
+
+```{r}
+manual <- checking %>%
+  select(id, aps_case_num, aps_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  intake_date <- pull(aps[aps$aps_row == pull(manual[i,'aps_row']), 
+                               'aps_intake_dt'])
+  
+  intake_window <- interval(start = intake_date - dhours(x=72), 
+                            end = intake_date)
+  ms_epcr_rows <- pull(medstar %>%
+                         filter((id == pull(manual[i,'id'])) &
+                                   (response_dt %within% intake_window)
+                                ) %>%
+                         select(ms_epcr_row)
+                    )
+  
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = pull(manual[i,'aps_case_num']),
+                        'aps_row' = pull(manual[i,'aps_row']),
+                        'ms_epcr_row' = ms_epcr_rows
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 39 potential EMS Response - APS Intake pairs. There were 22 APS Person IDs (89.52% failure rate) and APS Case Numbers (90.22% failure rate) with a potential match in the MedStar data set.
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+
+checking_ids <- unique(checking$id)
+```
+
+There were 12 APS Person IDs, represented by 29 APS Case Numbers, that were represented more than once in our initial mapping. Of these APS Case Numbers, there were 5 potential pairs that represented a repeated Intake.
+
+```{r}
+dup_ids <- temp_map %>%
+  filter(duplicated(id)|duplicated(id, fromLast = TRUE))
+
+length(unique(dup_ids$id))
+length(unique(dup_ids$aps_case_num))
+
+dup_cases <- temp_map %>%
+  filter(duplicated(aps_case_num)|duplicated(aps_case_num, fromLast = TRUE))
+
+nrow(dup_cases)
+length(unique(dup_cases$aps_case_num))
+length(unique(dup_cases$id))
+
+dup_rows <- temp_map %>%
+  filter(duplicated(aps_row)|duplicated(aps_row, fromLast = TRUE))
+
+identical(dup_cases, dup_rows)
+nrow(dup_cases) - length(unique(dup_cases$aps_row))
+
+length(unique(dup_ids[
+              !(dup_ids$aps_case_num %in% dup_cases$aps_case_num),
+              ]$aps_case_num
+              )
+       )
+```
+
+The 22 APS Person IDs in the initial mapping were verified.
+
+```{r}
+dup_ids <- temp_map
+
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 22 APS Person ID values checked, none appeared to lack any potentially valid match in the MedStar data set. Where multiple responses appeared to be temporally appropriate, the DETECT variables were examined. If there was no indication in the DETECT Variables, the most complete and temporally related record was selected if it did not appear otherwise inappropriate. We excluded the mismatched MedStar Responses, and isolated the APS Person IDs, Case Numbers, and Rows which were confirmed to have no apparent valid matches in the MedStar data set. There were 7 APS Person IDs that experienced multiple APS Intakes matched with a single MedStar Response; resolution of these groups resulted in no APS Case Numbers and 6 Intakes being confirmed to have no apparent potentially valid match in the MedStar data set. Of these, there were 3 APS Person IDs which required manual reassignment of pairs to resolve.
+
+```{r}
+dropping_ms_epcr_rows <- c(31861, 12621, 7411, 26307, 7107, 29173)
+
+dropping_aps_rows <- c(3077, 5305, 5306, 13580, 13581, 17937)
+
+temp_map <- temp_map %>%
+  filter( !((ms_epcr_row %in% dropping_ms_epcr_rows)|
+            (aps_row %in% dropping_aps_rows))
+          )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+dup_ids <- dup_ids %>%
+  filter(
+    !(aps_row %in% temp_map$aps_row)
+    ) %>%
+  select(-c(ms_epcr_row))
+```
+
+There were 3 APS IDs which required a single manual pair assignment to resolve.
+
+```{r}
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+point_map <- rbind(point_map, point_map_aps(509, 4066, 12621))
+point_map <- rbind(point_map, point_map_aps(1128, 7017, 7411))
+point_map <- rbind(point_map, point_map_aps(1962, 17918, 7107))
+```
+
+We verified that these particular APS Intakes were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+We appended our manually identified pairs to our section-wise map.
+
+```{r}
+temp_map <- rbind(temp_map, point_map)
+
+dup_ids <- dup_ids %>%
+  filter(
+    !(aps_row %in% temp_map$aps_row)
+    )
+```
+
+We confirmed that our section-wise sets of both confirmed and unconfirmed matches did not contain an APS Intake that overlapped in both sets. We also confirmed that neither set contained an APS Intake already present in either the overall MedStar Response-APS Intake pair map, or map of confirmed unmatched APS records. 
+
+```{r}
+sum(temp_map$aps_case_num %in% dup_ids$aps_case_num)
+sum(temp_map$aps_row %in% dup_ids$aps_row)
+
+sum(temp_map$id %in% intake_response_pairs$id)
+sum(temp_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(temp_map$aps_row %in% intake_response_pairs$aps_row)
+
+sum(temp_map$id %in% unmatched_aps_intakes$id)
+sum(temp_map$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(temp_map$aps_row %in% unmatched_aps_intakes$aps_row)
+
+sum(dup_ids$id %in% intake_response_pairs$id)
+sum(dup_ids$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(dup_ids$aps_row %in% intake_response_pairs$aps_row)
+
+sum(dup_ids$id %in% unmatched_aps_intakes$id)
+sum(dup_ids$aps_case_num %in% unmatched_aps_intakes$aps_case_num)
+sum(dup_ids$aps_row %in% unmatched_aps_intakes$aps_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, temp_map)
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, dup_ids)
+```
+
+### Remaining Unmatched EMS/EMT Reporter Intakes
+
+There were 13 remaining APS Intakes, representing 13 APS Case Numbers and APS Person IDs, which had not been paired or manually verified to include a matching MedStar Response.
+
+```{r}
+checking <- aps %>%
+  filter(!( (aps_row %in% intake_response_pairs$aps_row)|
+             (aps_row %in% unmatched_aps_intakes$aps_row)|
+              (id %in% manually_verified_ids))
+         ) %>%
+  filter(aps_reporter == potential_reporter_types[2])
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+These 13 APS Person IDs were manually verified.
+
+```{r}
+dup_ids <- checking
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+There was a single additional pair identified.
+
+```{r}
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+
+point_map <- rbind(point_map, point_map_aps(770, 7684, 15246))
+```
+
+We verified that this particular APS Intake was not otherwise represented in our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+We appended the results of this processing to our processing data frames.
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, point_map)
+```
+
+
+### Updates from Manually Checked ID List
+
+We ensured that all APS Case Numbers and APS Rows associated with the manually checked APS Person IDs were added to the confirmed unmatched APS set.
+
+```{r}
+manual_aps <- aps %>%
+  filter( (id %in% manually_verified_ids) & 
+            !((aps_row %in% intake_response_pairs$aps_row)|
+              (aps_row %in% unmatched_aps_intakes$aps_row))
+          ) %>%
+  select(id, aps_case_num, aps_row)
+
+unmatched_aps_intakes <- rbind(unmatched_aps_intakes, manual_aps) %>%
+  distinct()
+```
+
+
+## MedStar
+
+There were 2,523 remaining Responses, representing 645 MedStar Subject IDs, that had not yet been paired with an APS Response.
+
+```{r}
+checking <- medstar %>%
+  filter(!(ms_epcr_row %in% intake_response_pairs$ms_epcr_row))
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+Of these, 12 remaining Responses indicated an APS Report was made, 1,996 indicated that a report was *not* made, and 515 were missing a value to indicate if a report was made.
+
+```{r}
+get_unique_value_summary(checking, "detect_report_made")
+```
+
+### Responses Indicating a Report was Made
+
+There were 12 remaining Responses, across 11 MedStar Subject IDs, which indicated an APS report was made.
+
+```{r}
+checking <- medstar %>%
+  filter(!(ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+         ) %>%
+  filter(detect_report_made == "YES")
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+These 11 MedStar Subject IDs were manually verified.
+
+```{r}
+dup_ids <- checking %>%
+  select(id, ms_epcr_row)
+
+checking_ids <- unique(dup_ids$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Of the 11 MedStar Subject IDs manually verified, only two were not found to have a valid appearing pair. There was one additional pair identified.
+
+```{r}
+point_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+
+point_map <- rbind(point_map, point_map_aps(824, 9482, 19998))
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+```
+
+We verified that these particular MedStar Responses were not otherwise represented in either our section-wise temporary map our overall MedStar Response-APS Intake pair map. 
+
+```{r}
+sum(point_map$id %in% intake_response_pairs$id)
+sum(point_map$aps_case_num %in% intake_response_pairs$aps_case_num)
+sum(point_map$aps_row %in% intake_response_pairs$aps_row)
+sum(point_map$ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+```
+
+```{r}
+intake_response_pairs <- rbind(intake_response_pairs, point_map)
+```
+
+
+### Subjects With a Single Remaining Response
+
+There were 117 remaining MedStar Responses, which represented MedStar Subject IDs which appeared in a single remaining unmatched Response in the MedStar data set.
+
+```{r}
+checking <- medstar %>%
+  filter(!((ms_epcr_row %in% intake_response_pairs$ms_epcr_row)|
+             (id %in% manually_verified_ids))
+         ) %>%
+  filter( !(duplicated(id)|duplicated(id, fromLast=TRUE)) )
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+These 117 MedStar Subject IDs were manually checked for any potential matches.
+
+```{r}
+checking_ids <- unique(checking$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+No new potential matches were identified. We appended the manually verified IDs and their associated MedStar ePCR Rows to our processing data structures.
+
+```{r}
+dup_ids <- checking %>%
+  filter(!(ms_epcr_row %in% intake_response_pairs$ms_epcr_row)
+         ) %>%
+  select('id', 'ms_epcr_row')
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+
+unmatched_ms_responses <- rbind(unmatched_ms_responses, dup_ids)
+```
+
+
+### Responses Missing an Indication of a Report Being Made
+
+There were 236 remaining MedStar Responses, represented by 121 MedStar Subject IDs, which were missing a value indicating if a report was or was not made.
+
+```{r}
+checking <- medstar %>%
+  filter(!((ms_epcr_row %in% intake_response_pairs$ms_epcr_row)|
+             (ms_epcr_row %in% unmatched_ms_responses$ms_epcr_row)|
+             (id %in% manually_verified_ids))
+         )  %>%
+  filter(is.na(detect_report_made))
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+We assessed for potential matches in the APS data set. A 72 hour window from MedStar Response to APS Intake was selected for temporal proximity.
+
+```{r}
+manual <- checking %>%
+  select(id, ms_epcr_row)
+
+temp_map <- tibble("id" = c(), "aps_case_num" = c(), 
+                   "aps_row" = c(), "ms_epcr_row" = c()
+                   )
+
+for (i in 1:nrow(manual)){
+  response_date <- medstar[medstar$ms_epcr_row == pull(manual[i,'ms_epcr_row']),
+                            ]$response_dt
+  
+  intake_window <- interval(start = response_date, 
+                            end = response_date + dhours(72))
+    
+
+  aps_rows <- aps %>%
+    filter((id == pull(manual[i,'id'])) &
+              (aps_intake_dt %within% intake_window)
+            ) %>%
+     select(aps_case_num, aps_row)
+                  
+
+  temp_tibble <- tibble('id' = pull(manual[i,'id']), 
+                        'aps_case_num' = aps_rows$aps_case_num,
+                        'aps_row' = aps_rows$aps_row,
+                        'ms_epcr_row' = pull(manual[i,'ms_epcr_row'])
+  )
+  
+  temp_map <- rbind(temp_map, temp_tibble)
+  
+}
+```
+
+This isolated 4 potential EMS Response - APS Intake pairs. There were 3 APS Person IDs and APS Case Numbers matched with 3 MedStar Responses (98.81% failure rate).
+
+```{r}
+nrow(temp_map)
+length(unique(temp_map$id))
+length(unique(temp_map$aps_case_num))
+length(unique(temp_map$aps_row))
+length(unique(temp_map$ms_epcr_row))
+```
+
+These 3 MedStar Subject IDs were manually verified. 
+
+```{r}
+checking_ids <- unique(temp_map$id)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+There was a single mismatched APS Intake, which was adjusted to reference a more potentially valid MedStar Response. The remaining pairs appeared potentially valid, without additional potential pairs identified. 
+
+```{r}
+temp_map <- rbind(temp_map[temp_map$aps_row != 11603,], 
+                   point_map_aps(906, 11603, 5097))
+
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+```
+
+
+
+```{r}
+checking_ids <- setdiff(unique(checking$id), checking_ids)
+
+length(checking_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+No further potential pairs were identified.
+
+```{r}
+manually_verified_ids <- unique(c(manually_verified_ids, checking_ids))
+intake_response_pairs <- rbind(intake_response_pairs,temp_map)
+```
+
+### Updates from Manually Checked ID List
+
+We ensured that all MedStar ePCR Rows associated with the manually checked IDs were added to the confirmed unmatched MedStar set.
+
+```{r}
+manual_ms <- medstar %>%
+  filter((id %in% manually_verified_ids) &
+           !((ms_epcr_row %in% intake_response_pairs$ms_epcr_row)|
+             (ms_epcr_row %in% unmatched_ms_responses$ms_epcr_row))
+  ) %>%
+  select(id, ms_epcr_row)
+  
+unmatched_ms_responses <- rbind(unmatched_ms_responses, manual_ms) %>%
+  distinct()
+```
+
+# Check for Remaining Unmatched Values
+
+## Unmatched MedStar Responses Indicating a Report was Made
+
+There were 11 remaining MedStar Responses, across 10 MedStar Subject IDs, which either indicated an APS Report was made or contained an APS Report Number, that remained unmatched with an APS Intake.
+
+```{r}
+checking <- medstar %>%
+  filter( ((detect_report_made == "YES")|!is.na(detect_report_comment)) & 
+           !(ms_epcr_row %in% intake_response_pairs$ms_epcr_row))
+
+nrow(checking)
+length(unique(checking$id))
+```
+
+All 10 of these MedStar Subject IDs had been previously checked, but were rechecked.
+
+```{r}
+checking_ids <- unique(checking$id)
+
+length(checking_ids)
+sum(checking_ids %in% manually_verified_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+No additional pairs were found.
+
+## Unmatched APS Intakes Indicating EMS/EMT Reporter
+
+There were 29 remaining APS Intakes, across 28 APS Person IDs and APS Case Numbers, which indicated the reporter was an EMS/EMT professional and remained unmatched with a MedStar Response.
+
+```{r}
+checking <- aps %>%
+  filter( aps_reporter == potential_reporter_types[2] & 
+           !(aps_row %in% intake_response_pairs$aps_row))
+
+nrow(checking)
+length(unique(checking$id))
+length(unique(checking$aps_case_num))
+```
+
+All 28 of these MedStar Subject IDs had been previously checked, but were rechecked.
+
+```{r}
+checking_ids <- unique(checking$id)
+
+length(checking_ids)
+sum(checking_ids %in% manually_verified_ids)
+
+for (i in 1:length(checking_ids)){
+  t_id <- checking_ids[i]
+  aps[aps$id == t_id,]
+  medstar[medstar$id == t_id,]
+}
+```
+
+Two pairs were identified in which the MedStar Response was matched with another temporally proximal APS Intake which did not specify an EMS/EMT reporter; these two pairs were corrected.
+
+```{r}
+intake_response_pairs <- rbind(
+  intake_response_pairs[intake_response_pairs$aps_row != 962,],
+  point_map_aps(248, 961, 34870))
+
+intake_response_pairs <- rbind(
+  intake_response_pairs[intake_response_pairs$aps_row != 16878,],
+  point_map_aps(1589, 16879, 31176)
+)
+```
+
+
+# Checking Map
+
+The map of MedStar Response-APS Intake pairs contained 492 pairs, representing 461 APS Case Numbers and 422 Subjects
+
+```{r}
+nrow(intake_response_pairs)
+length(unique(intake_response_pairs$aps_case_num))
+length(unique(intake_response_pairs$id))
+```
+
+
+We verified that there were no instances where any APS Intake or MedStar Response was paired more than once. Similarly, we checked to ensure no typo errors caused the inclusion of an APS Intake or MedStar Response that did not exist in the source data sets.
+
+```{r}
+nrow(intake_response_pairs) == length(unique(intake_response_pairs$aps_row))
+nrow(intake_response_pairs) == length(unique(intake_response_pairs$ms_epcr_row))
+
+sum(!(intake_response_pairs$aps_row %in% aps$aps_row))
+sum(!(intake_response_pairs$ms_epcr_row %in% medstar$ms_epcr_row))
+```
+
+We tested to ensure no pairs were created between an APS Intake and any MedStar response that occurred *after* the Intake event.
+
+```{r}
+nrow(intake_response_pairs %>%
+  rowwise() %>%
+  mutate(intake_dt = aps[aps$aps_row == aps_row,]$aps_intake_dt,
+         response_dt = medstar[medstar$ms_epcr_row == ms_epcr_row,]$ms_epcr_row
+         ) %>%
+  filter(response_dt > intake_dt) %>%
+  ungroup()
+)
+```
+
+# Save and Export
+
+We saved and exported our map for later use.
+
+```{r}
+saveRDS(intake_response_pairs, 
+        here("data","DETECT Shared GRAs", "merge_aps_medstar", 
+             "medstar_aps_row_pair_map_01.rds"))
+```
+

--- a/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_03_refining_observations.qmd
@@ -100,7 +100,7 @@ We imported the Group ID merge pattern for processing.
 
 ```{r}
 merge_pattern <- readRDS(here("data","DETECT Shared GRAs","merge_aps_medstar",
-                              "aps_medstar_full_map_01"))
+                              "aps_medstar_full_subjid_map_01.rds"))
 ```
 
 ## Functions
@@ -2051,7 +2051,9 @@ intake_response_pairs <- rbind(
 ```
 
 
-# Checking Map
+# Map Verification and Application
+
+## Verification
 
 The map of MedStar Response-APS Intake pairs contained 492 pairs, representing 461 APS Case Numbers and 422 Subjects
 
@@ -2060,7 +2062,6 @@ nrow(intake_response_pairs)
 length(unique(intake_response_pairs$aps_case_num))
 length(unique(intake_response_pairs$id))
 ```
-
 
 We verified that there were no instances where any APS Intake or MedStar Response was paired more than once. Similarly, we checked to ensure no typo errors caused the inclusion of an APS Intake or MedStar Response that did not exist in the source data sets.
 
@@ -2085,6 +2086,67 @@ nrow(intake_response_pairs %>%
 )
 ```
 
+## Addition of Within-Set ID Values
+
+We added values for within-set Subject IDs and MedStar Compliance Row to our map.
+
+```{r}
+intake_response_pairs <- intake_response_pairs %>%
+  add_column(aps_person_id = NA_integer_, ms_id = NA_integer_, 
+             ms_comp_row = NA_integer_)
+```
+
+We added these values to our map from our trimmed source data sets.
+
+```{r}
+aps <- aps %>%
+  select(id, aps_person_id, aps_case_num, aps_row)
+
+intake_response_pairs <- rows_update(intake_response_pairs, aps, 
+                                      by = "aps_row", unmatched = "ignore")
+
+medstar <- medstar %>%
+  select(id, ms_id, ms_epcr_row, ms_comp_row)
+
+intake_response_pairs <- rows_update(intake_response_pairs, medstar, 
+                                      by = "ms_epcr_row", unmatched = "ignore")
+```
+
+## Applying Map to Source Data Sets
+
+We re-imported the revised MedStar data set, without any filtering or trimming, for processing.
+
+```{r}
+medstar <- readRDS(here("data","DETECT Shared GRAs", "medstar_cleaning",
+                        "medstar_02.rds"))
+```
+
+We re-imported the revised APS data set, without any filtering or trimming, for processing.
+
+```{r}
+aps <- readRDS(here("data","DETECT Shared GRAs", "aps_cleaning", "aps_04.rds"))
+```
+
+We added values for all within-set identifiers to both data sets.
+
+```{r}
+medstar <- medstar %>%
+  add_column(aps_person_id = NA_integer_, aps_case_num = NA_integer_, 
+             aps_row = NA_integer_)
+
+medstar <- rows_update(medstar, intake_response_pairs, by = "ms_epcr_row") %>%
+  relocate(id, ms_id, aps_person_id, aps_case_num, aps_row, ms_epcr_row, 
+           ms_comp_row)
+
+aps <- aps %>%
+  add_column(ms_id = NA_integer_, ms_epcr_row = NA_integer_, 
+             ms_comp_row = NA_integer_)
+
+aps <- rows_update(aps, intake_response_pairs, by = "aps_row") %>%
+    relocate(id, ms_id, aps_person_id, aps_case_num, aps_row, ms_epcr_row, 
+           ms_comp_row)
+```
+
 # Save and Export
 
 We saved and exported our map for later use.
@@ -2095,3 +2157,15 @@ saveRDS(intake_response_pairs,
              "medstar_aps_full_row_map_01.rds"))
 ```
 
+We saved the updated MedStar data set for later use.
+
+```{r}
+saveRDS(medstar, here("data","DETECT Shared GRAs", "medstar_cleaning",
+                        "medstar_03.rds"))
+```
+
+We saved the updated APS data set for later use.
+
+```{r}
+saveRDS(aps, here("data","DETECT Shared GRAs", "aps_cleaning", "aps_05.rds"))
+```

--- a/data_management/merge_aps_medstar/merge_aps_medstar_04_creating_merge_datasets.qmd
+++ b/data_management/merge_aps_medstar/merge_aps_medstar_04_creating_merge_datasets.qmd
@@ -1,0 +1,315 @@
+---
+title: "Merge APS and MedStar"
+format: html
+editor: visual
+---
+
+# Summary
+
+# Imports
+
+## Library Imports
+
+```{r}
+#| message: false
+#| warning: false
+
+library(tidyverse)
+library(here)
+library(lubridate)
+```
+
+## Data Imports
+
+We imported the revised MedStar data set for processing.
+
+```{r}
+medstar <- readRDS(here("data","DETECT Shared GRAs", "medstar_cleaning",
+                        "medstar_03.rds"))
+```
+
+We imported the revised APS data set for processing.
+
+```{r}
+aps <- readRDS(here("data","DETECT Shared GRAs", "aps_cleaning", "aps_05.rds"))
+```
+
+We imported the APS Intake-MedStar Response merge pattern for processing.
+
+```{r}
+row_pattern <- readRDS(here("data","DETECT Shared GRAs","merge_aps_medstar",
+                              "medstar_aps_full_row_map_01.rds"))
+```
+
+# Ordering Columns in Original Data Sets
+
+## APS
+
+We isolated variables from the APS data set into groups. 
+
+```{r}
+universal_id_vars <- aps %>%
+  select(id, aps_person_id, ms_id, aps_case_num, aps_row, 
+         ms_epcr_row, ms_comp_row) %>%
+  names()
+
+aps_pt_vars <- aps %>%
+  select(starts_with("pt_")) %>%
+  names()
+
+aps_event_vars <- aps %>%
+  select(aps_intake_dt, aps_intake_date, aps_intake_time, aps_intake_year, 
+         aps_intake_month, aps_intake_day) %>%
+  names()
+
+aps_inv_vars <- aps %>%
+  select(aps_intake_num, aps_inv_num, aps_inv_close_dt, aps_inv_close_date, aps_inv_close_time,
+         aps_inv_close_year, aps_inv_close_month, aps_inv_close_day) %>%
+  names()
+
+aps_row_vars <- aps %>%
+  select(aps_reporter, aps_inv_close_reason, all_of(starts_with("aps_rows_"))
+         ) %>%
+  names()
+
+aps_case_vars <- aps %>%
+  select(starts_with("aps_cases_")) %>%
+  names()
+
+aps_subj_vars <- aps %>%
+  select(starts_with("aps_subject_")) %>%
+  names()
+```
+
+We ordered the columns of our APS data set to facilitate additional analyses and merges.
+
+```{r}
+aps_cols <- c(universal_id_vars, aps_event_vars, aps_pt_vars, aps_row_vars, 
+              aps_case_vars, aps_subj_vars, aps_inv_vars)
+
+aps <- aps[,aps_cols]
+```
+
+We saved the revised data set for later use.
+
+```{r}
+saveRDS(aps, here("data","DETECT Shared GRAs", "aps_cleaning", "aps_06.rds"))
+```
+
+## MedStar
+
+We isolated variables from the MedStar data set into groups. 
+
+```{r}
+ms_pt_vars <- medstar %>%
+  select(starts_with("pt_")) %>%
+  names()
+
+ms_event_vars <- medstar %>%
+  select(response_dt, response_date, response_time, response_year,
+         response_month, response_day) %>%
+  names()
+
+ms_resp_front_vars <- medstar %>%
+  select(response_complaint, response_dispo) %>%
+  names()
+
+ms_resp_detail_vars <- medstar %>%
+  select(response_num, response_pcr, response_symptoms, 
+         response_ems_epcr_sig) %>%
+  names()
+
+ms_detect_vars <- medstar %>%
+  select(starts_with("detect_")) %>%
+  names()
+
+ms_comp_vars <- medstar %>%
+  select(starts_with("comp_")) %>%
+  names()
+```
+
+We ordered the columns of our MedStar data set to facilitate additional analyses and merges.
+
+```{r}
+ms_cols <- c(universal_id_vars, ms_event_vars, ms_pt_vars, ms_resp_front_vars, 
+              ms_detect_vars, ms_resp_detail_vars, ms_comp_vars)
+
+medstar <- medstar[,ms_cols]
+```
+
+We saved the revised data set for later use.
+
+```{r}
+saveRDS(medstar, here("data","DETECT Shared GRAs", "medstar_cleaning",
+                        "medstar_04.rds"))
+```
+
+# Modification of Patient Identifier Variables
+
+To appropriately merge the data sets, the patient identifier variables were made uniform between the data sets.
+
+```{r}
+pt_vars <- unique(c(ms_pt_vars, aps_pt_vars))
+
+pt_vars
+```
+
+There were three Patient Identifiers present in the MedStar data set that were missing in the APS Data Set: pt_name_middle, pt_race, pt_hispanic, pt_gender, and pt_address_state. These variables were added to the APS data set as missing values, and the data set was reordered.
+
+```{r}
+setdiff(pt_vars, aps_pt_vars)
+
+aps <- aps %>%
+  add_column(pt_name_middle = NA_character_, pt_race = NA_character_, 
+             pt_hispanic = NA, pt_gender = NA_character_, 
+             pt_address_state = NA_character_) %>%
+  relocate(all_of(universal_id_vars), all_of(aps_event_vars), all_of(pt_vars))
+```
+
+The only Patient Identifier present in the APS data set that was missing in the MedStar data set was pt_address_county. This variable was added to the MedStar data set as a missing value, and the data set was reordered.
+
+```{r}
+setdiff(pt_vars, ms_pt_vars)
+
+medstar <- medstar %>%
+  add_column(pt_address_county = NA_character_) %>%
+  relocate(all_of(universal_id_vars), all_of(ms_event_vars), all_of(pt_vars))
+```
+
+# Merges
+
+## Subject-Wise Timeline Merge
+
+A data set which combined all observations of both data sets was created, in order to facilitate the creation of a "timeline" for all observations for each subject across both data sets.
+
+The overall merge variables from each set were selected and ordered.
+
+```{r}
+aps_timeline_merge_cols <- c(aps_row_vars, aps_case_vars, aps_subj_vars, 
+                             aps_inv_vars)
+
+ms_timeline_merge_cols <- c(ms_resp_front_vars, ms_detect_vars, 
+                            ms_resp_detail_vars, ms_comp_vars)
+
+event_vars <- c("event_type", "event_dt", "event_date", "event_time", 
+                "event_year", "event_month", "event_day")
+
+timeline_cols <- c(universal_id_vars, event_vars, pt_vars, ms_resp_front_vars, 
+                   ms_detect_vars, aps_row_vars, aps_case_vars, aps_subj_vars, 
+                   aps_inv_vars, ms_resp_detail_vars, ms_comp_vars)
+```
+
+### APS
+
+The event type variable was added as "APS Intake" for all rows. The MedStar specific variables were added as missing values. MedStar Row numbers were converted to missing values.
+
+```{r}
+aps_modified <- aps %>%
+  add_column(event_type = "APS Intake") %>%
+  mutate(!!!setNames(rep(NA_character_, 
+                         length(ms_timeline_merge_cols)), 
+                         ms_timeline_merge_cols
+                     )
+         ) %>%
+  mutate(ms_epcr_row = NA_integer_,
+         ms_comp_row = NA_integer_) %>%
+  relocate(all_of(universal_id_vars), event_type, 
+           all_of(aps_event_vars), all_of(pt_vars))
+```
+
+We renamed the event variables for these APS Intakes.
+
+```{r}
+aps_modified <- aps_modified %>%
+    rename(event_dt = aps_intake_dt, event_date = aps_intake_date, 
+         event_time = aps_intake_time, event_year = aps_intake_year,
+         event_month = aps_intake_month, event_day = aps_intake_day)
+```
+
+### MedStar
+
+The event type variable was added as "MedStar Response" for all rows. The APS specific variables were added as missing values. APS Row numbers were converted to missing values.
+
+```{r}
+ms_modified <- medstar %>%
+  add_column(event_type = "MedStar Response") %>%
+  mutate(!!!setNames(rep(NA_character_, 
+                         length(aps_timeline_merge_cols)), 
+                         aps_timeline_merge_cols
+                     )
+         ) %>%
+  mutate(aps_row = NA_integer_) %>%
+  relocate(all_of(universal_id_vars), event_type, 
+           all_of(ms_event_vars), all_of(pt_vars))
+```
+
+We renamed the event variables for these MedStar Responses.
+
+```{r}
+ms_modified <- ms_modified %>%
+    rename(event_dt = response_dt, event_date = response_date, 
+         event_time = response_time, event_year = response_year,
+         event_month = response_month, event_day = response_day)
+```
+
+### Merge
+
+We merged the data sets, and arranged both our observations and variables.
+
+```{r}
+merged_set <- rbind(ms_modified, aps_modified) %>%
+  arrange(id, event_dt)
+
+merged_set <- merged_set[,timeline_cols]
+```
+
+We saved and exported this data set.
+
+```{r}
+saveRDS(merged_set, here("data","DETECT Shared GRAs","merge_aps_medstar",
+                              "medstar_aps_merged_01_timeline_all_rows.rds"))
+```
+
+## Row-Intake Merge Set
+
+A data set which added the APS data to any paired MedStar Response was created.
+
+The overall merge variables from each set were selected and ordered.
+
+```{r}
+row_merge_cols <- c(universal_id_vars, ms_event_vars, pt_vars, 
+                    ms_resp_front_vars, ms_detect_vars, aps_row_vars, 
+                    aps_case_vars, aps_subj_vars, aps_inv_vars, aps_event_vars, 
+                    ms_resp_detail_vars, ms_comp_vars)
+```
+
+We modified our MedStar Data set to eliminate the empty "pt_address_county" variable, and the APS Data Set to exclude any other patient identifier variable. We generated a simple key between the two data sets, consisting of both the MedStar Response and APS Intake. 
+
+```{r}
+ms_modified <- medstar %>%
+  mutate(key = paste(ms_epcr_row, aps_row, sep=", ")) %>%
+  select(-c(pt_address_county))
+
+aps_modified <- aps %>%
+  mutate(key = paste(ms_epcr_row, aps_row, sep=", ")
+         ) %>%
+  select(-c(all_of(universal_id_vars), all_of(ms_pt_vars)))
+```
+
+The APS Intakes with a match in the MedStar data set were added to their paired MedStar Responses.
+
+```{r}
+merged_set <- left_join(ms_modified, aps_modified, by="key") %>%
+  select(-c(key))
+
+merged_set <- merged_set[,row_merge_cols]
+```
+
+We saved and exported this data set.
+
+```{r}
+saveRDS(merged_set, here("data","DETECT Shared GRAs","merge_aps_medstar",
+                "medstar_aps_merged_02_response_based_row_pairs.rds"))
+```
+
+# BOTTOM


### PR DESCRIPTION
References #33 

Updates to cleaning of MedStar and APS data sets.

Documentation of Intake-Response Pair identification.

Documentation of Initial merged set creation initiated.